### PR TITLE
Allow the use of the Gradle wrapper for builds

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
@@ -1,38 +1,42 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-  <f:entry title="${%Gradle Version}">
-    <select class="setting-input" name="gradle.gradleName">
-      <option>(Default)</option>
-      <j:forEach var="inst" items="${descriptor.installations}">
-        <f:option selected="${inst.name==instance.gradle.name}">${inst.name}</f:option>
-      </j:forEach>
-    </select>
-  </f:entry>
+    <f:optionalBlock name="useWrapper" checked="${instance.useWrapper}"
+                     title="Use Gradle Wrapper" inline="true" negative="true">
+        <f:entry title="${%Gradle Version}">
+            <select class="setting-input" name="gradle.gradleName">
+                <option>(Default)</option>
+                <j:forEach var="inst" items="${descriptor.installations}">
+                    <f:option selected="${inst.name==instance.gradle.name}">${inst.name}</f:option>
+                </j:forEach>
+            </select>
+        </f:entry>
+    </f:optionalBlock>
 
-  <f:entry title="${%Build step description}" field="description">
-    <f:expandableTextbox />
-  </f:entry>
+    <f:entry title="${%Build step description}" field="description">
+        <f:expandableTextbox/>
+    </f:entry>
 
-  <f:entry title="${%Switches}" field="switches">
-    <f:expandableTextbox />
-  </f:entry>
+    <f:entry title="${%Switches}" field="switches">
+        <f:expandableTextbox/>
+    </f:entry>
 
 
-  <f:entry title="${%Tasks}" field="tasks">
-    <f:expandableTextbox  />
-  </f:entry>
+    <f:entry title="${%Tasks}" field="tasks">
+        <f:expandableTextbox/>
+    </f:entry>
 
-  <f:entry title="${%Root Build script}" field="rootBuildScriptDir">
-    <f:textbox  />
-  </f:entry>
+    <f:entry title="${%Root Build script}" field="rootBuildScriptDir">
+        <f:textbox/>
+    </f:entry>
 
-  <f:entry title="${%Build File}"
+    <f:entry title="${%Build File}"
              field="buildFile"
              description="
     Specify Gradle build file to run.
     Also, &lt;a href='${rootURL}/env-vars.html' target=_new>some environment variables are available to the build script&lt;/a>
     ">
-      <f:textbox />
-  </f:entry>
+        <f:textbox/>
+    </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
Let users use the Gradle wrapper, if it is used the Gradle installation selector is hidden, and the gradlew is executed at the root of the module
