### PR TITLE
Bugfix for JENKINS-9553 tested on Jenkins 1.435, linux master <> windows 7 slave and linux master <> linux slave on master. Please double check since I'm not familiar with jenkins coding :)

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -137,9 +137,8 @@ public class Gradle extends Builder implements DryRun {
         if (ai == null) {
             if (useWrapper) {
                 String execName = (Functions.isWindows()) ? GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND : GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND;
-                FilePath workspace = build.getModuleRoot();
-                File gradleWrapperFile = new File(workspace.getRemote(), execName);
-                args.add(gradleWrapperFile.getAbsolutePath());
+                FilePath gradleWrapperFile = new FilePath(build.getModuleRoot(), execName);
+                args.add(gradleWrapperFile.getRemote());
             } else {
                 args.add(launcher.isUnix() ? GradleInstallation.UNIX_GRADLE_COMMAND : GradleInstallation.WINDOWS_GRADLE_COMMAND);
             }


### PR DESCRIPTION
Fix for JENKINS-9553: use FilePath to build path to gradle wrapper on slave
