### PR TITLE
Change to invoke gradle via Java rather than gradle/gradle.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ work
 *.iml
 *.ipr
 *.iws
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.zenika.jenkins-ci.plugins</groupId>
     <artifactId>gradle</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>1.12</version>
     <packaging>hpi</packaging>
     <name>Jenkins Gradle plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.zenika.jenkins-ci.plugins</groupId>
     <artifactId>gradle</artifactId>
-    <version>1.12</version>
+    <version>1.13-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Gradle plugin</name>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Gradle+Plugin</url>

--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -4,13 +4,17 @@ import hudson.*;
 import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.util.ArgumentListBuilder;
+import hudson.util.ClasspathBuilder;
+import hudson.util.JVMBuilder;
 import net.sf.json.JSONObject;
 import org.jenkinsci.lib.dryrun.DryRun;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.io.FileFilter;
 import java.io.IOException;
 import java.util.Map;
 
@@ -150,65 +154,44 @@ public class Gradle extends Builder implements DryRun {
         normalizedTasks = Util.replaceMacro(normalizedTasks, env);
         normalizedTasks = Util.replaceMacro(normalizedTasks, build.getBuildVariables());
 
-        //Build arguments
-        ArgumentListBuilder args = new ArgumentListBuilder();
+        // Resolve Gradle installation and java environment
         GradleInstallation ai = getGradle();
-        String exe;
         if (ai == null) {
-            if (useWrapper) {
-                String execName = (Functions.isWindows()) ? GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND : GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND;
-                if( wrapperScript != null && wrapperScript.trim().length() != 0) {
-                    // Override with provided relative path to gradlew
-                    String wrapperScriptNormalized = wrapperScript.trim().replaceAll("[\t\r\n]+", "");
-                    wrapperScriptNormalized = Util.replaceMacro(wrapperScriptNormalized.trim(), env);
-                    wrapperScriptNormalized = Util.replaceMacro(wrapperScriptNormalized, build.getBuildVariableResolver());
-                    execName = wrapperScriptNormalized;
-                }
-
-                FilePath gradleWrapperFile = new FilePath(build.getModuleRoot(), execName);
-                if( !gradleWrapperFile.exists() ) {
-                    listener.fatalError("Unable to find Gradle Wrapper");
-                    return false;
-                }
-                exe = gradleWrapperFile.getRemote();
-            } else {
-                exe = launcher.isUnix() ? GradleInstallation.UNIX_GRADLE_COMMAND : GradleInstallation.WINDOWS_GRADLE_COMMAND;
-            }
-        } else {
-            ai = ai.forNode(Computer.currentComputer().getNode(), listener);
-            ai = ai.forEnvironment(env);
-            if (useWrapper) { // Can not happen, the Gradle installation is disabled if the useWrapper is checked
-                exe = ai.getWrapperExecutable(launcher, build);
-            } else {
-                exe = ai.getExecutable(launcher);
-            }
-        }
-
-        if (exe == null) {
-            listener.fatalError("ERROR");
+            launcher.getListener().error("Gradle installation not set, cannot build");
+            build.setResult(Result.FAILURE);
             return false;
         }
-        args.add(exe);
+        if (build.getEnvironment(listener).get("JAVA_HOME") == null) {
+            launcher.getListener().error("Missing JAVA_HOME in build environment. Make sure a JDK is selected for the project.");
+            build.setResult(Result.FAILURE);
+            return false;
+        }
 
-        args.addKeyValuePairs("-D", build.getBuildVariables());
-        args.addTokenized(normalizedSwitches);
-        args.addTokenized(normalizedTasks);
+        ai = ai.forNode(Computer.currentComputer().getNode(), listener);
+        ai = ai.forEnvironment(env);
+
+
+        // Build arguments, jvm options and classpath
+        final ClasspathBuilder classpath = new ClasspathBuilder();
+        final ArgumentListBuilder vmOptions = new ArgumentListBuilder();
+        final ArgumentListBuilder gradleArgs = new ArgumentListBuilder();
+
+        final FilePath libPath = new FilePath(new FilePath(launcher.getChannel(), ai.getHome()), "lib");
+        for (FilePath file : libPath.list("gradle-launcher*.jar")) {
+            classpath.add(file);
+        }
+
+        gradleArgs.addKeyValuePairs("-D", build.getBuildVariables());
+
+        gradleArgs.addTokenized(normalizedSwitches);
+        gradleArgs.addTokenized(normalizedTasks);
         if (buildFile != null && buildFile.trim().length() != 0) {
             String buildFileNormalized = Util.replaceMacro(buildFile.trim(), env);
-            args.add("-b");
-            args.add(buildFileNormalized);
+            gradleArgs.add("-b");
+            gradleArgs.add(buildFileNormalized);
         }
         if (ai != null) {
             env.put("GRADLE_HOME", ai.getHome());
-        }
-
-        if (!launcher.isUnix()) {
-            // on Windows, executing batch file can't return the correct error code,
-            // so we need to wrap it into cmd.exe.
-            // double %% is needed because we want ERRORLEVEL to be expanded after
-            // batch file executed, not before. This alone shows how broken Windows is...
-            args.prepend("cmd.exe", "/C");
-            args.add("&&", "exit", "%%ERRORLEVEL%%");
         }
 
         FilePath rootLauncher;
@@ -227,21 +210,29 @@ public class Gradle extends Builder implements DryRun {
         }
 
         try {
-            GradleConsoleAnnotator gca = new GradleConsoleAnnotator(
-                    listener.getLogger(), build.getCharset());
-            int r;
+            GradleConsoleAnnotator gca = new GradleConsoleAnnotator(listener.getLogger(), build.getCharset());
+            boolean success;
             try {
-                r = launcher.launch().cmds(args).envs(env).stdout(gca)
-                        .pwd(rootLauncher).join();
+                ArgumentListBuilder args = new ArgumentListBuilder();
+                final FilePath javaHome = new FilePath(launcher.getChannel(), build.getEnvironment(listener).get("JAVA_HOME"));
+                args.add(javaHome.child("bin").child("java").getRemote());
+                args.add("-cp").add(classpath.toString());
+                args.add(vmOptions.toCommandArray());
+                args.add("org.gradle.launcher.GradleMain");
+                args.add(gradleArgs.toCommandArray());
+
+                final int returnCode = launcher.launch()
+                        .cmds(args)
+                        .envs(env)
+                        .stdout(gca)
+                        .pwd(rootLauncher)
+                        .join();
+                success = returnCode == 0;
             } finally {
                 gca.forceEol();
             }
-            boolean success = r == 0;
             // if the build is successful then set it as success otherwise as a failure.
-            build.setResult(Result.SUCCESS);
-            if (!success) {
-                build.setResult(Result.FAILURE);
-            }
+            build.setResult(success ? Result.SUCCESS : Result.FAILURE);
             return success;
         } catch (IOException e) {
             Util.displayIOException(e, listener);


### PR DESCRIPTION
Using the gradle plugin together with the gerrit-trigger plugin, and with a remote windows jenkins build server revealed som problems related to windows command line parsing. The gerrit trigger adds several build parameters to a build, including the name and email off the person submitting a patch.

The parameter GERRIT_PATCHSET_UPLOADER gets the value "Firstname Lastname <user@example.com>". When this gets added as a command line argument to the gradle.bat file, windows interpets the "<" as a pipe from file, and fails to run the bat command since the file user@example.com is not found. In windows, command line arguments can be escaped with "^", however, that only worked for invoking the gradle bat script, and then caused different problems within the bat script. Even double escaping with "^^^<" didn't seem to fix the problem.

What this change does, is to look in the build environment for "JAVA_HOME", which is set by selecting a JDK for the build. It assumes that gradle is started by adding "gradle-launcher*.jar" to the class path from the lib folder off gradle home, and invoking "org.gradle.launcher.GradleMain". I have tested this for gradle-1.0-milestone-7, and the same will work for milestone-8. This change completly ignores the gradle wrapper setting, which I am not even sure what does. Maybe it's related to an old version off gradle.