### PR TITLE
Change Gradle Wrapper logic to use the launcher's OS type rather than master's OS type when determining Gradle Wrapper script name

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -139,7 +139,7 @@ public class Gradle extends Builder implements DryRun {
         GradleInstallation ai = getGradle();
         if (ai == null) {
             if (useWrapper) {
-                String execName = (Functions.isWindows()) ? GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND : GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND;
+                String execName = (launcher.isUnix()) ? GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND : GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND;
                 FilePath gradleWrapperFile = new FilePath(build.getModuleRoot(), execName);
                 args.add(gradleWrapperFile.getRemote());
             } else {


### PR DESCRIPTION
In my environment I have a Windows master and a Linux slave. I found I couldn't use the Gradle wrapper option of the plugin when the build was running on the slave as it was trying to use gradlew.bat rather than the gradlew shell script.

This patch changes the logic to look at the whether the slave is Unix or not to determine the wrapper name.
