### PR TITLE
JENKINS-12769/JENKINS-14272 - specifying custom gradlew location

### DIFF
--- a/src/main/java/hudson/plugins/gradle/GradleInstallation.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallation.java
@@ -9,6 +9,7 @@ import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
@@ -69,9 +70,15 @@ public class GradleInstallation extends ToolInstallation
         });
     }
 
-    public String getWrapperExecutable(final AbstractBuild<?, ?> build)
+    public String getWrapperExecutable(final AbstractBuild<?, ?> build, String wrapperLocation)
             throws IOException, InterruptedException {
-        return build.getModuleRoot().act(new FilePath.FileCallable<String>() {
+        FilePath gradleWrapperLocation;
+        if (StringUtils.isNotBlank(wrapperLocation)) {
+            gradleWrapperLocation = new FilePath(build.getModuleRoot(), wrapperLocation);
+        } else {
+            gradleWrapperLocation = build.getModuleRoot();
+        }
+        return gradleWrapperLocation.act(new FilePath.FileCallable<String>() {
             @Override
             public String invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
                 String execName = (Functions.isWindows()) ? WINDOWS_GRADLE_WRAPPER_COMMAND : UNIX_GRADLE_WRAPPER_COMMAND;

--- a/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
@@ -13,6 +13,10 @@
         </f:entry>
     </f:optionalBlock>
 
+    <f:entry title="${%Gradle wrapper location}" field="wrapperLocation">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%Build step description}" field="description">
         <f:expandableTextbox/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/gradle/Gradle/help-wrapperLocation.html
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/help-wrapperLocation.html
@@ -1,0 +1,5 @@
+<div>
+    If your workspace contains the Gradle wrapper executable somewhere other than the module root directory, specify the
+    directory path (relative to the module root) here, such as 'other/location'. If left empty, defaults to the module
+    root.
+</div>


### PR DESCRIPTION
Enable specification of a relative path to the gradlew executable within the workspace; supports also remote agents