### PR TITLE
Set GRADLE_USER_HOME all the time

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -183,6 +183,9 @@ public class Gradle extends Builder implements DryRun {
             env.put("GRADLE_HOME", ai.getHome());
         }
 
+        // Make user home relative to the workspace, so that files aren't shared between builds
+        env.put("GRADLE_USER_HOME", build.getWorkspace().getRemote());
+
         if (!launcher.isUnix()) {
             // on Windows, executing batch file can't return the correct error code,
             // so we need to wrap it into cmd.exe.


### PR DESCRIPTION
We have our home directory to read-only, so it detects things where builds are writing to a common location. I found that gradle will write to ~/.gradle by default, which is really bad for a multi-executor slave in Jenkins. Just setting the environment variable localized files to the workspace.
