### PR TITLE
Fix gerrit parameter handling for Windows

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -173,17 +173,17 @@ public class Gradle extends Builder implements DryRun {
         }
         ArgumentListBuilder args = new ArgumentListBuilder();
         if (useLauncherJar) {
-            if (normalizedLauncherJar != null) {
-                
-            } else if (useWrapper) {
-                String gradleLauncherJar = "gradle/wrapper/gradle-wrapper.jar";
-                normalizedLauncherJar = ((fromRootBuildScriptDir && (normalizedRootBuildScriptDir != null))
-                    ? new FilePath(normalizedRootBuildScriptDir, gradleLauncherJar)
-                    : new FilePath(build.getModuleRoot(), gradleLauncherJar));
-            } else if (ai != null) {
-                String str = ai.getLauncher(launcher);
-                if (str != null) {
-                    normalizedLauncherJar = new FilePath(launcher.getChannel(), str);
+            if (normalizedLauncherJar == null) {
+                if (useWrapper) {
+                    String gradleLauncherJar = "gradle/wrapper/gradle-wrapper.jar";
+                    normalizedLauncherJar = ((fromRootBuildScriptDir && (normalizedRootBuildScriptDir != null))
+                        ? new FilePath(normalizedRootBuildScriptDir, gradleLauncherJar)
+                        : new FilePath(build.getModuleRoot(), gradleLauncherJar));
+                } else if (ai != null) {
+                    String str = ai.getLauncher(launcher);
+                    if (str != null) {
+                        normalizedLauncherJar = new FilePath(launcher.getChannel(), str);
+                    }
                 }
             }
             if (normalizedLauncherJar == null) {
@@ -203,7 +203,7 @@ public class Gradle extends Builder implements DryRun {
             } else {
                 args.add(new File(jdk.getBinDir(), "java").getPath());
             }
-            args.add("-classpath").add(normalizedLauncherJar.getRemote()).add(className);
+            args.add("-cp").add(normalizedLauncherJar.getRemote()).add(className);
         }
         else if (useWrapper) {
             String execName = (launcher.isUnix()) ? GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND : GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND;
@@ -305,11 +305,6 @@ public class Gradle extends Builder implements DryRun {
         return strNormalized;
     }
     
-    private static boolean startQuoting(StringBuilder buf, String arg, int atIndex) {
-        buf.append('"').append(arg.substring(0, atIndex));
-        return true;
-    }
-
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();

--- a/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
@@ -20,6 +20,12 @@
         </f:entry>
     </f:radioBlock>
 
+    <f:optionalBlock field="useLauncherJar" title="${%Bypasses startup script}">
+        <f:entry title="${%Launcher/Wrapper jar path}" field="launcherJar">
+            <f:textbox/>
+        </f:entry>
+    </f:optionalBlock>
+    
     <f:entry title="${%Build step description}" field="description">
         <f:expandableTextbox/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/gradle/Gradle/help-launcherJar.html
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/help-launcherJar.html
@@ -1,0 +1,3 @@
+<div>
+    Specify launcher or wrapper jar. If not specified, it'll try 'gradle/wrapper/gradle-wrapper.jar' if you choose wrapper invocation, or '$GRADLE_HOME/lib/gradle-launcher*.jar' if you choose a gradle installation.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/Gradle/help-useLauncherJar.html
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/help-useLauncherJar.html
@@ -1,0 +1,3 @@
+<div>
+    Bypasses gradle[w][.bat] script, and directly invoke launcher/wrapper main class. Fixes issues with spaces &amp; quotes in arguments.
+</div>


### PR DESCRIPTION
Gerrit plugin adds many build variables, first one being:
-DGERRIT_PATCHSET_UPLOADER=\"Foo Bar\" foo.bar@acme.com
(with the back-slashes, as required on unix)

This causes issues with gradle depending on how it's escaped, either:
- gradle.bat fails if the first argument isn't 'quote-balanced' (and batch files don't recognize quote escaping through '\')
- gradle fails in jdk6 but not in jdk7 because of a java command line parsing change:
  http://gluck-md.blogspot.fr/2012/12/jdk7-surprise.html

Patch does 2 things:
- remove custom escaping and use the common jenkins one (used by Ant)
  (that alone isn't enough as it doesn't work for jdk below 7)
- add a configuration to bypass the startup script (both gradle.bat & gradlew.bat) and call directly java

Basically does what this pull request was meant to, but keeping gradlew support:
https://github.com/jenkinsci/gradle-plugin/pull/6
