### PR TITLE
 Add a new command to the CLI, get-gradle

### DIFF
--- a/src/main/java/hudson/plugins/gradle/GetGradleCommand.java
+++ b/src/main/java/hudson/plugins/gradle/GetGradleCommand.java
@@ -12,6 +12,7 @@ import hudson.tools.ToolPropertyDescriptor;
 import hudson.util.DescribableList;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
 import java.util.ArrayList;
@@ -79,8 +80,7 @@ public class GetGradleCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         if (help) {
-            // XXX printUsage() would be better
-            printUsageSummary(stderr);
+            printUsage(stderr, new CmdLineParser(this));
             return OK;
         }
 


### PR DESCRIPTION
This lists a subset of the known information about all gradle installations, formatted as JSON.  On the jenkins server, this information is stored in the file hudson.plugins.gradle.Gradle.xml.  What we are outputting here is a map, where the keys are the names of all of the gradle installations, and the values are an array of id's for all of the installers that correspond to the given installation.
