### PR TITLE
JENKINS-26287 Prevent the console-outline to overlap the console output

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/GradleTaskNote/DescriptorImpl/outline.jelly
+++ b/src/main/resources/hudson/plugins/gradle/GradleTaskNote/DescriptorImpl/outline.jelly
@@ -30,7 +30,9 @@ THE SOFTWARE.
         <td class='pane-header'>${%Executed Gradle Tasks}</td>
       </tr>
       <tr>
-        <td id='console-outline-body' />
+        <td id='console-outline-body'>
+        	<ul></ul>
+        </td>
       </tr>
     </table>
   </l:ajax>

--- a/src/main/resources/hudson/plugins/gradle/GradleTaskNote/script.js
+++ b/src/main/resources/hudson/plugins/gradle/GradleTaskNote/script.js
@@ -14,7 +14,8 @@
                     rootURL + "/descriptor/hudson.plugins.gradle.GradleTaskNote/outline",
             {insertion: Insertion.Bottom, onComplete: function() {
                 if (!u.success())   return; // we can't us onSuccess because that kicks in before onComplete
-                outline = document.getElementById("console-outline-body");
+                outline = document.getElementById("console-outline-body")
+                			.getElementsByTagName('ul')[0];
                 loading = false;
                 queue.each(handle);
             }});
@@ -27,7 +28,7 @@
             queue.push(e);
         } else {
             var id = "gradle-task-" + (iota++);
-            outline.appendChild(parseHtml("<li><a href='#" + id + "'>" + e.innerHTML + "</a></li>"))
+            outline.appendChild(parseHtml("<li><a href='#" + id + "'>" + e.innerHTML + "</a></li>"));
 
             if (document.all)
                 e.innerHTML += '<a name="' + id + '"/>';  // IE8 loses "name" attr in appendChild

--- a/src/main/resources/hudson/plugins/gradle/GradleTaskNote/style.css
+++ b/src/main/resources/hudson/plugins/gradle/GradleTaskNote/style.css
@@ -1,0 +1,8 @@
+#console-outline-body ul {
+	padding-left:5%;
+	word-wrap:break-word;
+}
+
+#console-outline-body ul li a {
+	word-break:break-all;
+}


### PR DESCRIPTION
JENKINS-26287 Prevent the console-outline block to overlap the console output in case of long task paths.

Add stylesheet and unorder list element for console-outline table  to
prevent it overlapping the console output in case of long task paths.