### PR TITLE
[JENKINS-17523] feat: Enable passing job parameter as properties

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -30,10 +30,12 @@ public class Gradle extends Builder implements DryRun {
     private final boolean makeExecutable;
     private final boolean fromRootBuildScriptDir;
     private final boolean useWorkspaceAsHome;
+    private final boolean passAsProperties;
 
     @DataBoundConstructor
     public Gradle(String description, String switches, String tasks, String rootBuildScriptDir, String buildFile,
-                  String gradleName, boolean useWrapper, boolean makeExecutable, boolean fromRootBuildScriptDir, boolean useWorkspaceAsHome) {
+                  String gradleName, boolean useWrapper, boolean makeExecutable, boolean fromRootBuildScriptDir,
+                  boolean useWorkspaceAsHome, boolean passAsProperties) {
         this.description = description;
         this.switches = switches;
         this.tasks = tasks;
@@ -44,6 +46,7 @@ public class Gradle extends Builder implements DryRun {
         this.makeExecutable = makeExecutable;
         this.fromRootBuildScriptDir = fromRootBuildScriptDir;
         this.useWorkspaceAsHome = useWorkspaceAsHome;
+        this.passAsProperties = passAsProperties;
     }
 
     @SuppressWarnings("unused")
@@ -94,6 +97,11 @@ public class Gradle extends Builder implements DryRun {
     @SuppressWarnings("unused")
     public boolean isUseWorkspaceAsHome() {
         return useWorkspaceAsHome;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isPassAsProperties() {
+        return passAsProperties;
     }
 
     public GradleInstallation getGradle() {
@@ -221,7 +229,7 @@ public class Gradle extends Builder implements DryRun {
         
        
         Set<String> sensitiveVars = build.getSensitiveBuildVariables();
-        args.addKeyValuePairs("-D", fixParameters(build.getBuildVariables()), sensitiveVars);
+        args.addKeyValuePairs(passPropertyOption(), fixParameters(build.getBuildVariables()), sensitiveVars);
         args.addTokenized(normalizedSwitches);
         args.addTokenized(normalizedTasks);
         if (buildFile != null && buildFile.trim().length() != 0) {
@@ -274,6 +282,10 @@ public class Gradle extends Builder implements DryRun {
             build.setResult(Result.FAILURE);
             return false;
         }
+    }
+
+    private String passPropertyOption() {
+        return passAsProperties ? "-P" : "-D";
     }
 
     private Map<String, String> fixParameters(Map<String, String> parmas) {

--- a/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/config.jelly
@@ -50,5 +50,9 @@
         <f:checkbox default="false"/>
     </f:entry>
 
+    <f:entry title="${%Pass job parameters as Gradle properties}" field="passAsProperties">
+        <f:checkbox default="false"/>
+    </f:entry>
+
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/gradle/Gradle/help-passAsProperties.html
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/help-passAsProperties.html
@@ -1,0 +1,5 @@
+<p>
+    Jenkins job parameters can be passed to Gradle either as Java system properties (<tt>-D</tt>), or as Gradle
+    properties (<tt>-P</tt>). Using properties has the advantage that job parameters are directly accessible in the
+    Gradle DSL, e.g. <tt>project.hasProperty(...)</tt>.
+</p>


### PR DESCRIPTION
As of version 1.24 of the Gradle plugin, all job parameters are passed as JVM system properties via '-D'. This change keeps the default behaviour, but allows to pass job parameters via regular Gradle properties, i.e. '-P' so that they are immediately available in the Gradle DSL.

To pick one or the other, the job config GUI contains an additional checkbox with a corresponding help text (as of now, in english only).

Fixes JENKINS-17523, JENKINS-17523