### PR TITLE
[FIXED JENKINS-42381] Add PATH+GRADLE and buildEnvVars(...)

### DIFF
--- a/src/main/java/hudson/plugins/gradle/GradleInstallation.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallation.java
@@ -63,6 +63,10 @@ public class GradleInstallation extends ToolInstallation
         return super.getHome();
     }
 
+    @Override
+    public void buildEnvVars(EnvVars env) {
+        env.put("PATH+GRADLE", getHome() + "/bin");
+    }
 
     public String getExecutable(Launcher launcher) throws IOException, InterruptedException {
         return launcher.getChannel().call(new MasterToSlaveCallable<String, IOException>() {

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -28,6 +28,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlButton
 import com.gargoylesoftware.htmlunit.html.HtmlForm
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.google.common.base.Joiner
+import hudson.EnvVars
 import hudson.model.Cause
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
@@ -270,6 +271,11 @@ task hello << { println 'Hello' }"""))
         def installation = installations[0]
         installation.name == 'myGradle'
         installation.home == '/tmp/foo'
+
+        def envVars = new EnvVars()
+        installation.buildEnvVars(envVars)
+        assert envVars.containsKey("PATH+GRADLE")
+        assert envVars.get("PATH+GRADLE") == installation.home + "/bin"
 
         // by default we should get the auto installer
         def props = installations[0].getProperties()


### PR DESCRIPTION
[JENKINS-42381](https://issues.jenkins-ci.org/browse/JENKINS-42381)

This ensures that Gradle's bin directory ends up on the PATH when
using the Pipeline tool step. Note that Jenkins' environment variable
management will handle converting "/bin" on Windows if needed, we do
not need to do that explicitly.

cc @reviewbybees and @wolfs 