### PR TITLE
[JENKINS-42847] Include automated test for CLI command

### DIFF
--- a/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -31,9 +31,20 @@ class GradleInstallationRule extends TestWatcher {
     }
 
     void addInstallation() {
+        addInstallations(gradleVersion)
+    }
+
+    void addInstallations(String... installationNames) {
         def gradleInstallationDescriptor = j.jenkins.getDescriptorByType(hudson.plugins.gradle.GradleInstallation.DescriptorImpl)
-        gradleInstallationDescriptor.setInstallations(
-                new GradleInstallation(gradleVersion, "", [new InstallSourceProperty([new GradleInstaller(gradleVersion)])]))
+
+        GradleInstallation[] installations = new GradleInstallation[installationNames.size()]
+
+        for (int i = 0; i < installationNames.size(); i++) {
+            String name = installationNames[i]
+            installations[i] = new GradleInstallation(name, "", [new InstallSourceProperty([new GradleInstaller(gradleVersion)])])
+        }
+
+        gradleInstallationDescriptor.setInstallations(installations)
 
         assert gradleInstallationDescriptor.getInstallations()
     }

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -302,7 +302,10 @@ task hello << { println 'Hello' }"""))
     }
 
     def 'list installations through CLI'() {
+        when:
         CLICommandInvoker.Result result = new CLICommandInvoker(j, "get-gradle").invoke()
+
+        then:
         assertCLIResult(result, true, '{}')
 
         when:
@@ -310,20 +313,20 @@ task hello << { println 'Hello' }"""))
         result = new CLICommandInvoker(j, "get-gradle").invoke()
 
         then:
-        assertCLIResult(result, true, '{"inst1":["3.2.1"]}')
+        assertCLIResult(result, true, expectedOutputForVersion('{"inst1":["%s"]}'))
 
         when:
         gradleInstallationRule.addInstallations("inst1", "inst2")
         result = new CLICommandInvoker(j, "get-gradle").invoke()
 
         then:
-        assertCLIResult(result, true, '{"inst1":["3.2.1"],"inst2":["3.2.1"]}')
+        assertCLIResult(result, true, expectedOutputForVersion('{"inst1":["%s"],"inst2":["%s"]}'))
 
         when:
         result = new CLICommandInvoker(j, "get-gradle").invokeWithArgs("--name=inst1")
 
         then:
-        assertCLIResult(result, true, '["3.2.1"]')
+        assertCLIResult(result, true, expectedOutputForVersion('["%s"]'))
 
         when:
         result = new CLICommandInvoker(j, "get-gradle").invokeWithArgs("--name=unknown")
@@ -357,6 +360,10 @@ task hello << { println 'Hello' }"""))
 
         Assert.assertEquals(expectedReturnCode, result.returnCode())
         Assert.assertEquals(expectedOutput + "\n", output)
+    }
+
+    private String expectedOutputForVersion(String output) {
+        return String.format(output, gradleInstallationRule.gradleVersion, gradleInstallationRule.gradleVersion)
     }
 
 }

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -357,7 +357,7 @@ task hello << { println 'Hello' }"""))
     }
 
     private void assertCLIResult(hudson.cli.CLICommandInvoker.Result result, String expectedOutput) {
-        assert 0 == result.returnCode()
+        assert result.returnCode() == 0
 
         JSON expectedJson, resultJson
 
@@ -369,12 +369,12 @@ task hello << { println 'Hello' }"""))
             resultJson = JSONObject.fromObject(result.stdout().trim())
         }
 
-        assert expectedJson == resultJson
+        assert resultJson == expectedJson
     }
 
     private void assertCLIError(hudson.cli.CLICommandInvoker.Result result, String expectedOutput) {
-        assert 1 == result.returnCode()
-        assert expectedOutput == result.stderr().trim()
+        assert result.returnCode() == 1
+        assert result.stderr().trim() == expectedOutput
 
     }
 

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -375,7 +375,6 @@ task hello << { println 'Hello' }"""))
     private void assertCLIError(hudson.cli.CLICommandInvoker.Result result, String expectedOutput) {
         assert result.returnCode() == 1
         assert result.stderr().trim() == expectedOutput
-
     }
 
     private String expectedOutputForVersion(String output) {

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -40,6 +40,9 @@ import hudson.model.TextParameterValue
 import hudson.remoting.Launcher
 import hudson.tools.InstallSourceProperty
 import hudson.util.VersionNumber
+import net.sf.json.JSON
+import net.sf.json.JSONArray
+import net.sf.json.JSONObject
 import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.jvnet.hudson.test.CreateFileBuilder
@@ -355,10 +358,23 @@ task hello << { println 'Hello' }"""))
 
     private void assertCLIResult(hudson.cli.CLICommandInvoker.Result result, boolean success, String expectedOutput) {
         int expectedReturnCode = success ? 0 : 1
-        String output = success ? result.stdout() : result.stderr()
-
         assert expectedReturnCode == result.returnCode()
-        assert expectedOutput == output.trim()
+
+        if (success) {
+            JSON expectedJson, resultJson
+
+            if (expectedOutput.startsWith("[")) {
+                expectedJson = JSONArray.fromObject(expectedOutput)
+                resultJson = JSONArray.fromObject(result.stdout().trim())
+            } else {
+                expectedJson = JSONObject.fromObject(expectedOutput)
+                resultJson = JSONObject.fromObject(result.stdout().trim())
+            }
+
+            assert expectedJson == resultJson
+        } else {
+            assert expectedOutput == result.stderr().trim()
+        }
     }
 
     private String expectedOutputForVersion(String output) {

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -40,7 +40,6 @@ import hudson.model.TextParameterValue
 import hudson.remoting.Launcher
 import hudson.tools.InstallSourceProperty
 import hudson.util.VersionNumber
-import org.junit.Assert
 import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.jvnet.hudson.test.CreateFileBuilder
@@ -358,8 +357,8 @@ task hello << { println 'Hello' }"""))
         int expectedReturnCode = success ? 0 : 1
         String output = success ? result.stdout() : result.stderr()
 
-        Assert.assertEquals(expectedReturnCode, result.returnCode())
-        Assert.assertEquals(expectedOutput + "\n", output)
+        assert expectedReturnCode == result.returnCode()
+        assert expectedOutput == output.trim()
     }
 
     private String expectedOutputForVersion(String output) {


### PR DESCRIPTION
[JENKINS-42847](https://issues.jenkins-ci.org/browse/JENKINS-42847)

Include automated test for _get-gradle_ CLI command, which allows to gather the configured Gradle installations.

@reviewbybees @wolfs 