### PR TITLE
[JENKINS-44126] Include animal-sniffer and findbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ findbugs {
 }
 
 codenarc {
-  // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
   toolVersion '0.27.0'
   sourceSets = [sourceSets.test]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id "org.jenkins-ci.jpi" version "0.22.0"
   id 'ru.vyarus.animalsniffer' version '1.3.0'
   id 'findbugs'
+  id 'codenarc'
 }
 
 group = "org.jenkins-ci.plugins"
@@ -68,6 +69,13 @@ findbugs {
   // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
   toolVersion '3.0.0'
   ignoreFailures false
+  sourceSets = [sourceSets.main]
+}
+
+codenarc {
+  // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
+  toolVersion '0.27.0'
+  sourceSets = [sourceSets.test]
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
   id "org.jenkins-ci.jpi" version "0.22.0"
+  id 'ru.vyarus.animalsniffer' version '1.3.0'
+  id 'findbugs'
 }
 
 group = "org.jenkins-ci.plugins"
@@ -46,6 +48,8 @@ dependencies {
   compileOnly 'org.jenkins-ci:symbol-annotation:1.3'
   jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.3@jar'
 
+  signature 'org.codehaus.mojo.signature:java16:1.1@signature'
+
   testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
   jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.8@jar'
 }
@@ -56,6 +60,16 @@ if (project.hasProperty("maxParallelForks")) {
   ext.maxParallelForks = 3
 }
 
+animalsniffer {
+  ignoreFailures true // https://github.com/gradle/gradle/issues/1305
+}
+
+findbugs {
+  // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
+  toolVersion '3.0.0'
+  ignoreFailures false
+
+}
 
 test {
   systemProperties["hudson.model.DownloadService.noSignatureCheck"] = "true"

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ findbugs {
   // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
   toolVersion '3.0.0'
   ignoreFailures false
-
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -62,13 +62,12 @@ if (project.hasProperty("maxParallelForks")) {
 }
 
 animalsniffer {
-  ignoreFailures true // https://github.com/gradle/gradle/issues/1305
+  sourceSets = [sourceSets.main]
 }
 
 findbugs {
   // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
   toolVersion '3.0.0'
-  ignoreFailures false
   sourceSets = [sourceSets.main]
 }
 
@@ -76,6 +75,11 @@ codenarc {
   // Some errors are logged due to https://github.com/gradle/gradle/issues/1094, but Findbugs checks are working fine
   toolVersion '0.27.0'
   sourceSets = [sourceSets.test]
+}
+
+configurations {
+  // https://github.com/gradle/gradle/issues/1305
+  compile.exclude group: 'com.ibm.icu', module: 'icu4j'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   compileOnly 'org.jenkins-ci:symbol-annotation:1.3'
   jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.3@jar'
 
-  signature 'org.codehaus.mojo.signature:java16:1.1@signature'
+  signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
   testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
   jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.8@jar'

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -1,0 +1,15 @@
+<ruleset xmlns="http://codenarc.org/ruleset/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
+    <ruleset-ref path='rulesets/basic.xml'>
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/braces.xml'/>
+    <ruleset-ref path='rulesets/concurrency.xml'/>
+    <ruleset-ref path='rulesets/design.xml'>
+        <exclude name="PublicInstanceField"/> <!-- JUnit rules -->
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/dry.xml'/>
+    <ruleset-ref path='rulesets/exceptions.xml'/>
+    <ruleset-ref path='rulesets/groovyism.xml'/>
+    <ruleset-ref path='rulesets/imports.xml'/>
+</ruleset>

--- a/src/main/java/hudson/plugins/gradle/GetGradleCommand.java
+++ b/src/main/java/hudson/plugins/gradle/GetGradleCommand.java
@@ -85,7 +85,7 @@ public class GetGradleCommand extends CLICommand {
         }
 
         GradleInstallation[] installations =
-            Jenkins.getInstance().getDescriptorByType(GradleInstallation.DescriptorImpl.class).getInstallations();
+            Jenkins.getActiveInstance().getDescriptorByType(GradleInstallation.DescriptorImpl.class).getInstallations();
 
         Map<String,List<String>> map = new HashMap<String,List<String>>();
 

--- a/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -1,5 +1,6 @@
 package hudson.plugins.gradle
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import hudson.tools.InstallSourceProperty
 import hudson.util.FormValidation
 import org.junit.rules.TestWatcher
@@ -24,6 +25,7 @@ class GradleInstallationRule extends TestWatcher {
         loadGradleToolInstallers()
     }
 
+    @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Due to closure")
     private void loadGradleToolInstallers() {
         assert j.jenkins.getExtensionList(hudson.model.DownloadService.Downloadable).find {
             it.id == GradleInstaller.name

--- a/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -1,6 +1,5 @@
 package hudson.plugins.gradle
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import hudson.tools.InstallSourceProperty
 import hudson.util.FormValidation
 import org.junit.rules.TestWatcher
@@ -13,7 +12,7 @@ class GradleInstallationRule extends TestWatcher {
     }
 
     String gradleVersion
-    private JenkinsRule j
+    private final JenkinsRule j
 
     GradleInstallationRule(String gradleVersion = '3.2.1', JenkinsRule j) {
         this.gradleVersion = gradleVersion
@@ -25,7 +24,6 @@ class GradleInstallationRule extends TestWatcher {
         loadGradleToolInstallers()
     }
 
-    @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Due to closure")
     private void loadGradleToolInstallers() {
         assert j.jenkins.getExtensionList(hudson.model.DownloadService.Downloadable).find {
             it.id == GradleInstaller.name

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -28,6 +28,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlButton
 import com.gargoylesoftware.htmlunit.html.HtmlForm
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.google.common.base.Joiner
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import hudson.EnvVars
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
@@ -43,6 +44,7 @@ import static org.jvnet.hudson.test.JenkinsRule.getLog
  * Tests for the Gradle build step.
  */
 @Unroll
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Due to closure")
 class GradlePluginIntegrationTest extends AbstractIntegrationTest {
     def 'run the default tasks'() {
         given:

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -24,11 +24,12 @@
 
 package hudson.plugins.gradle
 
+import static org.jvnet.hudson.test.JenkinsRule.getLog
+
 import com.gargoylesoftware.htmlunit.html.HtmlButton
 import com.gargoylesoftware.htmlunit.html.HtmlForm
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.google.common.base.Joiner
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import hudson.EnvVars
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
@@ -39,12 +40,10 @@ import org.jvnet.hudson.test.CreateFileBuilder
 import org.jvnet.hudson.test.JenkinsRule.WebClient
 import spock.lang.Unroll
 
-import static org.jvnet.hudson.test.JenkinsRule.getLog
 /**
  * Tests for the Gradle build step.
  */
 @Unroll
-@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Due to closure")
 class GradlePluginIntegrationTest extends AbstractIntegrationTest {
     def 'run the default tasks'() {
         given:

--- a/src/test/groovy/hudson/plugins/gradle/GradleTaskNoteTest.java
+++ b/src/test/groovy/hudson/plugins/gradle/GradleTaskNoteTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.gradle;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.MarkupText;
 import org.junit.After;
 import org.junit.Before;
@@ -17,6 +18,7 @@ public class GradleTaskNoteTest {
     }
 
     @After
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Done for testing purposes")
     public void tearDown() {
         // Restore the original setting.
         GradleTaskNote.ENABLED = enabled;
@@ -66,6 +68,7 @@ public class GradleTaskNoteTest {
     }
 
     @Test
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Done for testing purposes")
     public void testDisabled() {
         GradleTaskNote.ENABLED = false;
         assertEquals("TASK:", annotate("TASK:"));

--- a/src/test/groovy/hudson/plugins/gradle/GradleTaskNoteTest.java
+++ b/src/test/groovy/hudson/plugins/gradle/GradleTaskNoteTest.java
@@ -1,6 +1,5 @@
 package hudson.plugins.gradle;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.MarkupText;
 import org.junit.After;
 import org.junit.Before;
@@ -18,7 +17,6 @@ public class GradleTaskNoteTest {
     }
 
     @After
-    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Done for testing purposes")
     public void tearDown() {
         // Restore the original setting.
         GradleTaskNote.ENABLED = enabled;
@@ -68,7 +66,6 @@ public class GradleTaskNoteTest {
     }
 
     @Test
-    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Done for testing purposes")
     public void testDisabled() {
         GradleTaskNote.ENABLED = false;
         assertEquals("TASK:", annotate("TASK:"));

--- a/src/test/groovy/hudson/plugins/gradle/PropertyPassingIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/PropertyPassingIntegrationTest.groovy
@@ -1,6 +1,7 @@
 package hudson.plugins.gradle
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import static org.jvnet.hudson.test.JenkinsRule.getLog
+
 import hudson.model.Cause
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
@@ -13,10 +14,7 @@ import hudson.remoting.Launcher
 import org.jvnet.hudson.test.CreateFileBuilder
 import spock.lang.Unroll
 
-import static org.jvnet.hudson.test.JenkinsRule.getLog
-
 @Unroll
-@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Due to closure")
 class PropertyPassingIntegrationTest extends AbstractIntegrationTest {
     def "pass '#escapedPropertyValue' via parameter in system properties"() {
         given:

--- a/src/test/groovy/hudson/plugins/gradle/PropertyPassingIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/PropertyPassingIntegrationTest.groovy
@@ -1,5 +1,6 @@
 package hudson.plugins.gradle
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import hudson.model.Cause
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
@@ -15,6 +16,7 @@ import spock.lang.Unroll
 import static org.jvnet.hudson.test.JenkinsRule.getLog
 
 @Unroll
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Due to closure")
 class PropertyPassingIntegrationTest extends AbstractIntegrationTest {
     def "pass '#escapedPropertyValue' via parameter in system properties"() {
         given:


### PR DESCRIPTION
[JENKINS-44126](https://issues.jenkins-ci.org/browse/JENKINS-44126)

Findbugs and animal-sniffer analyses are really useful for development.

- Execute animal sniffer when building.
- Execute Findbugs when building.
- Fix Findbugs errors.

@reviewbybees @wolfs 