### PR TITLE
Build variables that are empty are removed

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -228,7 +228,6 @@ public class Gradle extends Builder implements DryRun {
         gradleLogger.info("Launching build.");
 
         EnvVars env = build.getEnvironment(listener);
-        env.overrideAll(build.getBuildVariables());
         final VariableResolver<String> resolver = new VariableResolver.ByMap<>(env);
 
         //Switches


### PR DESCRIPTION
By utilizing the EnvVars.overrideAll(Map) method, it internally removes keys where the value is null or an empty string. In some cases, users that I'm supporting have optional build parameters being utilized. This results in those parameters not being rewritten to empty properties as expected and the properties instead have the jenkins replacement string in them instead.

Example (tasks block):
```
:sometask -PPROPERTY=${OPTIONAL_PROPERTY}
```

If OPTIONAL_PROPERTY is a Jenkins build variable and it is left blank, we end up getting an incorrect value.

As workaround, we can remove the property from the tasks block itself and use the pass as gradle properties checkbox.