### PR TITLE
Don't remove empty build vars

### DIFF
--- a/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
@@ -1,5 +1,13 @@
 package hudson.plugins.gradle
 
+import hudson.model.Cause
+import hudson.model.FreeStyleBuild
+import hudson.model.FreeStyleProject
+import hudson.model.ParametersAction
+import hudson.model.ParametersDefinitionProperty
+import hudson.model.TextParameterDefinition
+import hudson.model.TextParameterValue
+import hudson.model.queue.QueueTaskFuture
 import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.jvnet.hudson.test.JenkinsRule
@@ -14,4 +22,13 @@ class AbstractIntegrationTest extends Specification {
     Map getDefaults() {
         [gradleName: gradleInstallationRule.gradleVersion, useWorkspaceAsHome: true, switches: '--no-daemon']
     }
+
+    static QueueTaskFuture<FreeStyleBuild> triggerBuildWithParameter(FreeStyleProject p, String parameterName, String value) {
+        p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(new TextParameterValue(parameterName, value)))
+    }
+
+    static addParameter(FreeStyleProject p, String parameterName) {
+        p.addProperty(new ParametersDefinitionProperty(new TextParameterDefinition(parameterName, null, null)))
+    }
+
 }

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -150,6 +150,27 @@ class GradlePluginIntegrationTest extends AbstractIntegrationTest {
         'build/some/build.gradle' | [rootBuildScriptDir: 'build']                                                               | [null]
     }
 
+    def "empty parameters are replaced"() {
+        given:
+        gradleInstallationRule.addInstallation()
+        def p = j.createFreeStyleProject()
+        p.buildersList.add(new CreateFileBuilder('build.gradle', """
+            task printParameter {
+                doLast {
+                    println "PASSED_PARAMETER='\$passedParameter'"
+                }
+            }
+        """.stripIndent()))
+        p.buildersList.add(new Gradle(defaults + [tasks: 'printParameter -PpassedParameter=$PASSED_PARAMETER']))
+        addParameter(p, 'PASSED_PARAMETER')
+
+        when:
+        def build = triggerBuildWithParameter(p, 'PASSED_PARAMETER', '').get()
+
+        then:
+        getLog(build).contains("PASSED_PARAMETER=''")
+    }
+
     def "Config roundtrip"() {
         given:
         gradleInstallationRule.addInstallation()

--- a/src/test/groovy/hudson/plugins/gradle/PropertyPassingIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/PropertyPassingIntegrationTest.groovy
@@ -2,14 +2,7 @@ package hudson.plugins.gradle
 
 import static org.jvnet.hudson.test.JenkinsRule.getLog
 
-import hudson.model.Cause
-import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
-import hudson.model.ParametersAction
-import hudson.model.ParametersDefinitionProperty
-import hudson.model.TextParameterDefinition
-import hudson.model.TextParameterValue
-import hudson.model.queue.QueueTaskFuture
 import hudson.remoting.Launcher
 import org.jvnet.hudson.test.CreateFileBuilder
 import spock.lang.Unroll
@@ -138,13 +131,5 @@ class PropertyPassingIntegrationTest extends AbstractIntegrationTest {
 
     private static String map2PropertiesString(Map<String, String> properties) {
         (properties.collect { k, v -> "${k}=${v}\n" }).join('')
-    }
-
-    private static QueueTaskFuture<FreeStyleBuild> triggerBuildWithParameter(FreeStyleProject p, String parameterName, String value) {
-        p.scheduleBuild2(0, new Cause.UserIdCause(), new ParametersAction(new TextParameterValue(parameterName, value)))
-    }
-
-    private static addParameter(FreeStyleProject p, String parameterName) {
-        p.addProperty(new ParametersDefinitionProperty(new TextParameterDefinition(parameterName, null, null)))
     }
 }


### PR DESCRIPTION
By utilizing the EnvVars.overrideAll(Map) method, it internally removes keys where the value is null or an empty string. This results in those parameters not being rewritten to empty properties as expected and the properties instead have the jenkins replacement string in them instead.

[FIXES JENKINS-45300]