### PR TITLE
Added a licensing definition to the Maven project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ jenkinsPlugin {
 
   licenses {
     license {
-      name 'The MIT License'
+      name 'MIT License'
       distribution 'repo'
       url 'https://opensource.org/licenses/MIT'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ jenkinsPlugin {
     license {
       name 'The MIT License'
       distribution 'repo'
+      url 'https://opensource.org/licenses/MIT'
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,13 @@ jenkinsPlugin {
     }
   }
 
+  licenses {
+    license {
+      name 'The MIT License'
+      distribution 'repo'
+    }
+  }
+
   disabledTestInjection = false
 }
 


### PR DESCRIPTION
In order to meet the [prerequisites](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Prerequisites) of plugin hosting in the Jenkins Organization, I'm adding the licensing definition in the Maven project.

@reviewbybees, What do you think?
