### PR TITLE
[JENKINS-51062] JEP-200 issue with plugin Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.util.zip.ZipFile
 
 plugins {
-  id "org.jenkins-ci.jpi" version "0.22.0"
+  id "org.jenkins-ci.jpi" version "0.24.0"
   id 'ru.vyarus.animalsniffer' version '1.3.0'
   id 'findbugs'
   id 'codenarc'

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,8 @@ dependencies {
   signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
   testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
-  jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.8@jar'
+  jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.38@jar'
+  compile 'junit:junit:4.12'
 }
 
 if (project.hasProperty("maxParallelForks")) {

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,6 +1,0 @@
-hudson.plugins.gradle.BuildScanAction
-hudson.plugins.gradle.Gradle
-hudson.plugins.gradle.Gradle$DescriptorImpl
-hudson.plugins.gradle.GradleInstallation
-hudson.plugins.gradle.GradleInstallation$DescriptorImpl
-hudson.plugins.gradle.GradleInstaller

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,6 @@
+hudson.plugins.gradle.BuildScanAction
+hudson.plugins.gradle.Gradle
+hudson.plugins.gradle.Gradle$DescriptorImpl
+hudson.plugins.gradle.GradleInstallation
+hudson.plugins.gradle.GradleInstallation$DescriptorImpl
+hudson.plugins.gradle.GradleInstaller


### PR DESCRIPTION
See [JENKINS-51062](https://issues.jenkins-ci.org/browse/JENKINS-51062)

- Add the hudson.remoting.ClassFilter since all the involved classes seems to be fine (non transient field are String)
- Upgrade `org.jenkins-ci.jpi` to version 0.24.0 to avoid the use of war-for-test when checking the compatibility with newer core versions.

@reviewbybees @jglick @oleg-nenashev @wolfs 