### PR TITLE
Implemented gradle pipeline step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.util.zip.ZipFile
 
 plugins {
-  id "org.jenkins-ci.jpi" version "0.22.0"
+  id 'org.jenkins-ci.jpi' version '0.23.1'
   id 'ru.vyarus.animalsniffer' version '1.3.0'
   id 'findbugs'
   id 'codenarc'
@@ -18,7 +18,7 @@ if (ciBuild) {
 
 jenkinsPlugin {
   // Version of Jenkins core this plugin depends on.
-  coreVersion = "1.642.1"
+  coreVersion = "1.642.3"
 
   // Human-readable name of plugin.
   displayName = "Gradle Plugin"
@@ -55,14 +55,21 @@ jenkinsPlugin {
 sourceCompatibility = '1.7'
 
 dependencies {
-  compile 'org.jenkins-ci.lib:dry-run-lib:0.1'
-  compileOnly 'org.jenkins-ci:symbol-annotation:1.3'
-  jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.3@jar'
+  jenkinsPlugins 'org.jenkins-ci.plugins:dry-run:0.9'
+  jenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.11'
+  jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.7'
+  jenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-support:1.14'
 
   signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
   testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
-  jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.8@jar'
+  testCompile 'org.jenkins-ci.main:jenkins-test-harness:2.22@jar'
+  testCompile 'org.jenkins-ci.main:jenkins-test-harness-tools:2.2'
+
+  jenkinsTest 'org.jenkins-ci.plugins.workflow:workflow-cps:2.32'
+  jenkinsTest 'org.jenkins-ci.plugins.workflow:workflow-job:2.11'
+  jenkinsTest 'org.jenkins-ci.plugins.workflow:workflow-basic-steps:2.5'
+  jenkinsTest 'org.jenkins-ci.plugins.workflow:workflow-durable-task-step:2.9'
 }
 
 if (project.hasProperty("maxParallelForks")) {
@@ -79,6 +86,9 @@ configurations {
   animalsnifferCompileClasspath.extendsFrom compile
   // We need to exclude this dependency from animalsniffer since contains an invalid class
   animalsnifferCompileClasspath.exclude group: 'com.ibm.icu', module: 'icu4j'
+  // junit-dep:4.10 cannot be replaced by junit:4.12 since the artifactIds are different
+  // gibut is causing binary compatibility issues. Exclude it completely from classpath
+  runtime.exclude group: 'junit', module: 'junit-dep'
 }
 
 findbugs {

--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -1,41 +1,34 @@
 package hudson.plugins.gradle;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import hudson.CopyOnWrite;
-import hudson.EnvVars;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.Util;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
-import hudson.model.Node;
-import hudson.model.Result;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.Builder;
-import hudson.tools.ToolInstallation;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.VariableResolver;
-import org.apache.commons.lang.StringUtils;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
 import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.dryrun.DryRun;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import hudson.CopyOnWrite;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.tools.ToolInstallation;
+import hudson.util.VariableResolver;
 
 
 /**
+ * {@link Builder} for Freestyle-Builds to execute Gradle.
+ * 
  * @author Gregory Boissinot
  */
-public class Gradle extends Builder implements DryRun {
+public class Gradle extends Builder implements DryRun, GradleInstallationProvider {
 
     private String switches;
     private String tasks;
@@ -54,11 +47,22 @@ public class Gradle extends Builder implements DryRun {
     private boolean passAllAsProjectProperties;
 
     private transient boolean fromRootBuildScriptDir;
+    
+    private String logEncoding;
 
     @DataBoundConstructor
     public Gradle() {
     }
 
+    @DataBoundSetter
+    public void setLogEncoding(String logEncoding) {
+        this.logEncoding = logEncoding;
+    }
+    
+    public String getLogEncoding() {
+        return logEncoding;
+    }
+    
     @SuppressWarnings("unused")
     public String getSwitches() {
         return switches;
@@ -185,35 +189,6 @@ public class Gradle extends Builder implements DryRun {
         this.passAllAsProjectProperties = passAllAsProjectProperties;
     }
 
-    public GradleInstallation getGradle() {
-        for (GradleInstallation i : getDescriptor().getInstallations()) {
-            if (gradleName != null && i.getName().equals(gradleName)) {
-                return i;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Turns a null string into a blanck string.
-     */
-    private static String null2Blank(String input) {
-        return input != null ? input : "";
-    }
-
-    /**
-     * Appends text to a possibly null string.
-     */
-    private static String append(String input, String textToAppend) {
-        if (StringUtils.isBlank(input)) {
-            return null2Blank(textToAppend);
-        }
-        if (StringUtils.isBlank(textToAppend)) {
-            return null2Blank(input);
-        }
-        return input + " " + textToAppend;
-    }
-
     @Override
     public boolean performDryRun(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         return performTask(true, build, launcher, listener);
@@ -227,186 +202,42 @@ public class Gradle extends Builder implements DryRun {
 
     private boolean performTask(boolean dryRun, AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
-
-        GradleLogger gradleLogger = new GradleLogger(listener);
-        gradleLogger.info("Launching build.");
-
+        
+        
         EnvVars env = build.getEnvironment(listener);
-        VariableResolver.Union<String> resolver = new VariableResolver.Union<>(new VariableResolver.ByMap<>(env), build.getBuildVariableResolver());
-
-        //Switches
-        String normalizedSwitches = getNormalized(switches, resolver, "GRADLE_EXT_SWITCHES");
-
-        //Add dry-run switch if needed
-        if (dryRun) {
-            normalizedSwitches = normalizedSwitches + " --dry-run";
-        }
-
-        //Tasks
-        String normalizedTasks = getNormalized(tasks, resolver, "GRADLE_EXT_TASKS");
-
-        FilePath normalizedRootBuildScriptDir = getNormalizedRootBuildScriptDir(build, resolver);
-
-        //Build arguments
-        ArgumentListBuilder args = new ArgumentListBuilder();
-        if (useWrapper) {
-            FilePath gradleWrapperFile = findGradleWrapper(normalizedRootBuildScriptDir, build, launcher, listener, resolver);
-            if (gradleWrapperFile == null) {
-                return false;
-            }
-            if (makeExecutable) {
-                gradleWrapperFile.chmod(0755);
-            }
-            args.add(gradleWrapperFile.getRemote());
-        } else {
-            //Look for a gradle installation
-            GradleInstallation ai = getGradle();
-            if (ai != null) {
-                Computer computer = Computer.currentComputer();
-                Node node = computer != null ? computer.getNode() : null;
-                if (node != null) {
-                    ai = ai.forNode(node, listener);
-                    ai = ai.forEnvironment(env);
-                    String exe = ai.getExecutable(launcher);
-                    if (exe == null) {
-                        gradleLogger.error("Can't retrieve the Gradle executable.");
-                        return false;
-                    }
-                    env.put("GRADLE_HOME", ai.getHome());
-                    args.add(exe);
-                } else {
-                    gradleLogger.error("Not in a build node.");
-                    return false;
-                }
-            } else {
-                //No gradle installation either, fall back to simple command
-                args.add(launcher.isUnix() ? GradleInstallation.UNIX_GRADLE_COMMAND : GradleInstallation.WINDOWS_GRADLE_COMMAND);
-            }
-        }
-
-
-        Set<String> sensitiveVars = build.getSensitiveBuildVariables();
-        args.addKeyValuePairsFromPropertyString("-D", getSystemProperties(), resolver, sensitiveVars);
-        if (isPassAllAsSystemProperties()) {
-            args.addKeyValuePairs("-D", build.getBuildVariables(), sensitiveVars);
-        }
-        args.addKeyValuePairsFromPropertyString("-P", getProjectProperties(), resolver, sensitiveVars);
-        if (isPassAllAsProjectProperties()) {
-            args.addKeyValuePairs("-P", build.getBuildVariables(), sensitiveVars);
-        }
-        args.addTokenized(normalizedSwitches);
-        args.addTokenized(normalizedTasks);
-        if (StringUtils.isNotBlank(buildFile)) {
-            String buildFileNormalized = Util.replaceMacro(buildFile.trim(), resolver);
-            args.add("-b");
-            args.add(buildFileNormalized);
-        }
-
-        final FilePath workspace = build.getWorkspace();
-        if (useWorkspaceAsHome && workspace != null) {
-            // Make user home relative to the workspace, so that files aren't shared between builds
-            env.put("GRADLE_USER_HOME", workspace.getRemote());
-        }
-
-        if (!launcher.isUnix()) {
-            args = args.toWindowsCommand();
-        }
-
-        FilePath rootLauncher;
-        if (normalizedRootBuildScriptDir != null) {
-            rootLauncher = normalizedRootBuildScriptDir;
-        } else {
-            rootLauncher = build.getWorkspace();
-        }
-
-        //Not call from an Executor
-        if (rootLauncher == null) {
-            rootLauncher = build.getProject().getSomeWorkspace();
-        }
-
-        try {
-            GradleConsoleAnnotator gca = new GradleConsoleAnnotator(
-                    listener.getLogger(), build.getCharset());
-            int r;
-            try {
-                r = launcher.launch().cmds(args).envs(env).stdout(gca)
-                        .pwd(rootLauncher).join();
-            } finally {
-                gca.forceEol();
-            }
-            boolean success = r == 0;
-            // if the build is successful then set it as success otherwise as a failure.
-            build.setResult(Result.SUCCESS);
-            if (!success) {
-                build.setResult(Result.FAILURE);
-            }
-            String scanUrl = gca.getScanUrl();
-            if (StringUtils.isNotEmpty(scanUrl)) {
-                build.addAction(new BuildScanAction(scanUrl));
-            }
-            return success;
-        } catch (IOException e) {
-            Util.displayIOException(e, listener);
-            e.printStackTrace(listener.fatalError("command execution failed"));
-            build.setResult(Result.FAILURE);
-            return false;
-        }
-    }
-
-    private FilePath findGradleWrapper(FilePath normalizedRootBuildScriptDir, AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, VariableResolver<String> resolver) throws IOException, InterruptedException {
-        List<FilePath> possibleWrapperLocations = getPossibleWrapperLocations(build, launcher, resolver, normalizedRootBuildScriptDir);
-        String execName = (launcher.isUnix()) ? GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND : GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND;
-        FilePath gradleWrapperFile = null;
-        for (FilePath possibleWrapperLocation : possibleWrapperLocations) {
-            final FilePath possibleGradleWrapperFile = new FilePath(possibleWrapperLocation, execName);
-            if (possibleGradleWrapperFile.exists()) {
-                gradleWrapperFile = possibleGradleWrapperFile;
-                break;
-            }
-        }
-        if (gradleWrapperFile == null) {
-            listener.fatalError("The Gradle wrapper has not been found in these directories: %s", Joiner.on(", ").join(possibleWrapperLocations));
-        }
-        return gradleWrapperFile;
-    }
-
-    private FilePath getNormalizedRootBuildScriptDir(AbstractBuild<?, ?> build, VariableResolver<String> resolver) {
-        FilePath normalizedRootBuildScriptDir = null;
-        if (rootBuildScriptDir != null && rootBuildScriptDir.trim().length() != 0) {
-            String rootBuildScriptNormalized = replaceWhitespaceBySpace(rootBuildScriptDir.trim());
-            rootBuildScriptNormalized = Util.replaceMacro(rootBuildScriptNormalized.trim(), resolver);
-            normalizedRootBuildScriptDir = new FilePath(build.getModuleRoot(), rootBuildScriptNormalized);
-        }
-        return normalizedRootBuildScriptDir;
-    }
-
-    private String getNormalized(String args, VariableResolver<String> resolver, String contributingEnvironmentVariable) {
-        String extraArgs = resolver.resolve(contributingEnvironmentVariable);
-        String normalizedArgs = append(args, extraArgs);
-        normalizedArgs = replaceWhitespaceBySpace(normalizedArgs);
-        normalizedArgs = Util.replaceMacro(normalizedArgs, resolver);
-        return normalizedArgs;
-    }
-
-    private String replaceWhitespaceBySpace(String argument) {
-        return argument.replaceAll("[\t\r\n]+", " ");
-    }
-
-    private List<FilePath> getPossibleWrapperLocations(AbstractBuild<?, ?> build, Launcher launcher, VariableResolver<String> resolver, FilePath normalizedRootBuildScriptDir) throws IOException, InterruptedException {
-        FilePath moduleRoot = build.getModuleRoot();
-        if (wrapperLocation != null && wrapperLocation.trim().length() != 0) {
-            // Override with provided relative path to gradlew
-            String wrapperLocationNormalized = wrapperLocation.trim().replaceAll("[\t\r\n]+", "");
-            wrapperLocationNormalized = Util.replaceMacro(wrapperLocationNormalized.trim(), resolver);
-            return ImmutableList.of(new FilePath(moduleRoot, wrapperLocationNormalized));
-        } else if (buildFile != null && !buildFile.isEmpty()) {
-            // Check if the target project is located not at the root dir
-            FilePath parentOfBuildFile = new FilePath(normalizedRootBuildScriptDir == null ? moduleRoot : normalizedRootBuildScriptDir, buildFile).getParent();
-            if (parentOfBuildFile != null && !parentOfBuildFile.equals(moduleRoot)) {
-                return ImmutableList.of(parentOfBuildFile, moduleRoot);
-            }
-        }
-        return ImmutableList.of(moduleRoot);
+        VariableResolver<String> resolver= 
+            new VariableResolver.Union<>(
+                new VariableResolver.ByMap<>(env), 
+                ((AbstractBuild) build).getBuildVariableResolver());
+        
+        return new GradleExecution(
+            switches, 
+            tasks, 
+            rootBuildScriptDir, 
+            buildFile,
+            gradleName, 
+            useWrapper, 
+            makeExecutable, 
+            useWorkspaceAsHome,
+            wrapperLocation, 
+            systemProperties,
+            passAllAsSystemProperties, 
+            projectProperties, 
+            passAllAsProjectProperties,
+            this,
+            logEncoding
+        ).performTask(
+            dryRun, 
+            build,
+            launcher,
+            listener,
+            build.getWorkspace(), 
+            build.getModuleRoot(), 
+            resolver,
+            env,
+            build.getBuildVariables()
+        );
+        
     }
 
     private Object readResolve() {
@@ -426,6 +257,11 @@ public class Gradle extends Builder implements DryRun {
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
+    }
+    
+    @Override
+    public GradleInstallation[] getInstallations() {
+        return ((DescriptorImpl) getDescriptor()).getInstallations();
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/gradle/GradleExecution.java
+++ b/src/main/java/hudson/plugins/gradle/GradleExecution.java
@@ -1,0 +1,332 @@
+package hudson.plugins.gradle;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.VariableResolver;
+
+/**
+ * Helper for execution of an Gradle build.
+ * Encapsulates the real gradle execution independent of build type.
+ */
+public final class GradleExecution {
+
+    private String switches;
+    private String tasks;
+    private String rootBuildScriptDir;
+    private String buildFile;
+    private String gradleName;
+    private boolean useWrapper;
+    private boolean makeExecutable;
+    private boolean useWorkspaceAsHome;
+    private String wrapperLocation;
+    private String systemProperties;
+    private boolean passAllAsSystemProperties;
+    private String logEncoding;
+
+    private String projectProperties;
+    private boolean passAllAsProjectProperties;
+
+    private final GradleInstallationProvider installationProvider;
+
+    public GradleExecution(
+            String switches, 
+            String tasks, 
+            String rootBuildScriptDir, 
+            String buildFile,
+            String gradleName, 
+            boolean useWrapper, 
+            boolean makeExecutable, 
+            boolean useWorkspaceAsHome,
+            String wrapperLocation, 
+            String systemProperties,
+            boolean passAllAsSystemProperties, 
+            String projectProperties, 
+            boolean passAllAsProjectProperties,
+            GradleInstallationProvider installationProvider,
+            String logEncoding) {
+        
+        this.switches = switches;
+        this.tasks = tasks;
+        this.rootBuildScriptDir = rootBuildScriptDir;
+        this.buildFile = buildFile;
+        this.gradleName = gradleName;
+        this.useWrapper = useWrapper;
+        this.makeExecutable = makeExecutable;
+        this.useWorkspaceAsHome = useWorkspaceAsHome;
+        this.wrapperLocation = wrapperLocation;
+        this.systemProperties = systemProperties;
+        this.passAllAsSystemProperties = passAllAsSystemProperties;
+        this.projectProperties = projectProperties;
+        this.passAllAsProjectProperties = passAllAsProjectProperties;
+        this.installationProvider = installationProvider;
+        this.logEncoding = logEncoding;
+    }
+
+    public GradleInstallation getGradle() {
+        for (GradleInstallation i : installationProvider.getInstallations()) {
+            if (gradleName != null && i.getName().equals(gradleName)) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Turns a null string into a blank string.
+     */
+    private static String null2Blank(String input) {
+        return input != null ? input : "";
+    }
+
+    /**
+     * Appends text to a possibly null string.
+     */
+    private static String append(String input, String textToAppend) {
+        if (StringUtils.isBlank(input)) {
+            return null2Blank(textToAppend);
+        }
+        if (StringUtils.isBlank(textToAppend)) {
+            return null2Blank(input);
+        }
+        return input + " " + textToAppend;
+    }
+
+
+    /**
+     * Executes the gradle build.
+     * 
+     * @return Returns <code>true</code> if gradle was executed successfully and returned return code 0.
+     */
+    boolean performTask(
+            boolean dryRun,
+            Run<?, ?> build,
+            Launcher launcher,
+            TaskListener listener,
+            FilePath workspace,
+            FilePath moduleRoot,
+            VariableResolver<String> resolver,
+            EnvVars env,
+            Map<String, String> buildVariables) throws InterruptedException, IOException {
+
+        GradleLogger gradleLogger = new GradleLogger(listener);
+        gradleLogger.info("Launching build.");
+
+        //Switches
+        String normalizedSwitches = getNormalized(switches, resolver, "GRADLE_EXT_SWITCHES");
+
+        //Add dry-run switch if needed
+        if (dryRun) {
+            normalizedSwitches = normalizedSwitches + " --dry-run";
+        }
+
+        //Tasks
+        String normalizedTasks = getNormalized(tasks, resolver, "GRADLE_EXT_TASKS");
+
+        FilePath normalizedRootBuildScriptDir = getNormalizedRootBuildScriptDir(build, resolver, moduleRoot);
+
+        //Build arguments
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        if (useWrapper) {
+            FilePath gradleWrapperFile = findGradleWrapper(normalizedRootBuildScriptDir, build, launcher, listener, resolver, moduleRoot);
+            if (gradleWrapperFile == null) {
+                gradleLogger.error("GradleWrapper not found.");
+                build.setResult(Result.FAILURE);
+                return false;
+            }
+            if (makeExecutable) {
+                gradleWrapperFile.chmod(0755);
+            }
+            args.add(gradleWrapperFile.getRemote());
+        } else {
+            //Look for a gradle installation
+            GradleInstallation ai = getGradle();
+            if (ai != null) {
+                Computer computer = workspace.toComputer();
+                Node node = computer == null ? null : computer.getNode();
+                if (node != null) {
+                    ai = ai.forNode(node, listener);
+                    ai = ai.forEnvironment(env);
+                    String exe = ai.getExecutable(launcher);
+                    if (exe == null) {
+                        gradleLogger.error("Can't retrieve the Gradle executable for gradle installation " + ai.getName() + " on node " + node.getNodeName());
+                        build.setResult(Result.FAILURE);
+                        return false;
+                    }
+                    env.put("GRADLE_HOME", ai.getHome());
+                    args.add(exe);
+                } else {
+                    gradleLogger.error("Not in a build node.");
+                    build.setResult(Result.FAILURE);
+                    return false;
+                }
+            } else {
+                //No gradle installation either, fall back to simple command
+                args.add(launcher.isUnix() ? GradleInstallation.UNIX_GRADLE_COMMAND : GradleInstallation.WINDOWS_GRADLE_COMMAND);
+            }
+        }
+
+        Set<String> sensitiveVars;
+        if (build instanceof AbstractBuild) {
+            sensitiveVars = ((AbstractBuild<?, ?>) build).getSensitiveBuildVariables();
+        } else {
+            sensitiveVars = Collections.emptySet();
+        }
+
+        args.addKeyValuePairsFromPropertyString("-D", systemProperties, resolver, sensitiveVars);
+        args.addKeyValuePairsFromPropertyString("-P", projectProperties, resolver, sensitiveVars);
+
+        if (passAllAsSystemProperties) {
+            args.addKeyValuePairs("-D", buildVariables, sensitiveVars);
+        }
+        if (passAllAsProjectProperties) {
+            args.addKeyValuePairs("-P", buildVariables, sensitiveVars);
+        }
+
+        args.addTokenized(normalizedSwitches);
+        args.addTokenized(normalizedTasks);
+        if (StringUtils.isNotBlank(buildFile)) {
+            String buildFileNormalized = Util.replaceMacro(buildFile.trim(), resolver);
+            args.add("-b");
+            args.add(buildFileNormalized);
+        }
+
+        if (useWorkspaceAsHome && workspace != null) {
+            // Make user home relative to the workspace, so that files aren't shared between builds
+            env.put("GRADLE_USER_HOME", workspace.getRemote());
+        }
+
+        if (!launcher.isUnix()) {
+            args = args.toWindowsCommand();
+        }
+
+        FilePath rootLauncher;
+        if (normalizedRootBuildScriptDir != null) {
+            rootLauncher = normalizedRootBuildScriptDir;
+        } else {
+            rootLauncher = workspace;
+        }
+
+        //Not call from an Executor
+        if (rootLauncher == null && build instanceof AbstractBuild) {
+            rootLauncher = ((AbstractBuild<?, ?>) build).getParent().getSomeWorkspace();
+        }
+
+        try {
+            if (rootLauncher == null) {
+                throw new IOException("Directory for gradle execution could not be determined.");
+            }
+
+            GradleConsoleAnnotator gca = new GradleConsoleAnnotator(
+                listener.getLogger(),
+                this.logEncoding == null ? build.getCharset() : Charset.forName(logEncoding)
+            );
+
+            int r;
+            try {
+                r = launcher
+                    .launch()
+                    .cmds(args)
+                    .envs(env)
+                    .stdout(gca)
+                    .pwd(rootLauncher)
+                    .join();
+            } finally {
+                gca.forceEol();
+            }
+            gradleLogger.info("Gradle finished with rc " + r);
+
+            boolean success = r == 0;
+            // if the build is successful then set it as success otherwise as a failure.
+            build.setResult(Result.SUCCESS);
+            if (!success) {
+                build.setResult(Result.FAILURE);
+            }
+            String scanUrl = gca.getScanUrl();
+            if (StringUtils.isNotEmpty(scanUrl)) {
+                build.addAction(new BuildScanAction(scanUrl));
+            }
+            return success;
+        } catch (IOException e) {
+            Util.displayIOException(e, listener);
+            e.printStackTrace(listener.fatalError("command execution failed"));
+            build.setResult(Result.FAILURE);
+            return false;
+        }
+    }
+
+    private FilePath findGradleWrapper(FilePath normalizedRootBuildScriptDir, Run<?, ?> build, Launcher launcher, TaskListener listener, VariableResolver<String> resolver, FilePath buildScriptRoot) throws IOException, InterruptedException {
+        List<FilePath> possibleWrapperLocations = getPossibleWrapperLocations(build, launcher, resolver, normalizedRootBuildScriptDir, buildScriptRoot);
+        String execName = (launcher.isUnix()) ? GradleInstallation.UNIX_GRADLE_WRAPPER_COMMAND : GradleInstallation.WINDOWS_GRADLE_WRAPPER_COMMAND;
+        FilePath gradleWrapperFile = null;
+        for (FilePath possibleWrapperLocation : possibleWrapperLocations) {
+            FilePath possibleGradleWrapperFile = new FilePath(possibleWrapperLocation, execName);
+            if (possibleGradleWrapperFile.exists()) {
+                gradleWrapperFile = possibleGradleWrapperFile;
+                break;
+            }
+        }
+        if (gradleWrapperFile == null) {
+            listener.fatalError("The Gradle wrapper has not been found in these directories: %s", Joiner.on(", ").join(possibleWrapperLocations));
+        }
+        return gradleWrapperFile;
+    }
+
+    private FilePath getNormalizedRootBuildScriptDir(Run<?, ?> build, VariableResolver<String> resolver, FilePath moduleRoot) {
+        FilePath normalizedRootBuildScriptDir = null;
+        if (rootBuildScriptDir != null && rootBuildScriptDir.trim().length() != 0) {
+            String rootBuildScriptNormalized = replaceWhitespaceBySpace(rootBuildScriptDir.trim());
+            rootBuildScriptNormalized = Util.replaceMacro(rootBuildScriptNormalized.trim(), resolver);
+            normalizedRootBuildScriptDir = new FilePath(moduleRoot, rootBuildScriptNormalized);
+        }
+        return normalizedRootBuildScriptDir;
+    }
+
+    private static String getNormalized(String args, VariableResolver<String> resolver, String contributingEnvironmentVariable) {
+        String extraArgs = resolver.resolve(contributingEnvironmentVariable);
+        String normalizedArgs = append(args, extraArgs);
+        normalizedArgs = replaceWhitespaceBySpace(normalizedArgs);
+        normalizedArgs = Util.replaceMacro(normalizedArgs, resolver);
+        return normalizedArgs;
+    }
+
+    private static String replaceWhitespaceBySpace(String argument) {
+        return argument.replaceAll("[\t\r\n]+", " ");
+    }
+
+    private List<FilePath> getPossibleWrapperLocations(Run<?, ?> build, Launcher launcher, VariableResolver<String> resolver, FilePath normalizedRootBuildScriptDir, FilePath moduleRoot) throws IOException, InterruptedException {
+        if (wrapperLocation != null && wrapperLocation.trim().length() != 0) {
+            // Override with provided relative path to gradlew
+            String wrapperLocationNormalized = wrapperLocation.trim().replaceAll("[\t\r\n]+", "");
+            wrapperLocationNormalized = Util.replaceMacro(wrapperLocationNormalized.trim(), resolver);
+            return ImmutableList.of(new FilePath(moduleRoot, wrapperLocationNormalized));
+        } else if (buildFile != null && !buildFile.isEmpty()) {
+            // Check if the target project is located not at the root dir
+            FilePath parentOfBuildFile = new FilePath(normalizedRootBuildScriptDir == null ? moduleRoot : normalizedRootBuildScriptDir, buildFile).getParent();
+            if (parentOfBuildFile != null && !parentOfBuildFile.equals(moduleRoot)) {
+                return ImmutableList.of(parentOfBuildFile, moduleRoot);
+            }
+        }
+        return ImmutableList.of(moduleRoot);
+    }
+}

--- a/src/main/java/hudson/plugins/gradle/GradleExecution.java
+++ b/src/main/java/hudson/plugins/gradle/GradleExecution.java
@@ -31,21 +31,21 @@ import hudson.util.VariableResolver;
  */
 public final class GradleExecution {
 
-    private String switches;
-    private String tasks;
-    private String rootBuildScriptDir;
-    private String buildFile;
-    private String gradleName;
-    private boolean useWrapper;
-    private boolean makeExecutable;
-    private boolean useWorkspaceAsHome;
-    private String wrapperLocation;
-    private String systemProperties;
-    private boolean passAllAsSystemProperties;
-    private String logEncoding;
+    private final String switches;
+    private final String tasks;
+    private final String rootBuildScriptDir;
+    private final String buildFile;
+    private final String gradleName;
+    private final boolean useWrapper;
+    private final boolean makeExecutable;
+    private final boolean useWorkspaceAsHome;
+    private final String wrapperLocation;
+    private final String systemProperties;
+    private final boolean passAllAsSystemProperties;
+    private final String logEncoding;
 
-    private String projectProperties;
-    private boolean passAllAsProjectProperties;
+    private final String projectProperties;
+    private final boolean passAllAsProjectProperties;
 
     private final GradleInstallationProvider installationProvider;
 

--- a/src/main/java/hudson/plugins/gradle/GradleInstallation.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallation.java
@@ -2,6 +2,7 @@ package hudson.plugins.gradle;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,7 +34,7 @@ import jenkins.security.MasterToSlaveCallable;
  */
 public class GradleInstallation 
         extends ToolInstallation
-        implements EnvironmentSpecific<GradleInstallation>, NodeSpecific<GradleInstallation> {
+        implements EnvironmentSpecific<GradleInstallation>, NodeSpecific<GradleInstallation>, Serializable {
 
     private static final long serialVersionUID = -1875114350592080381L;
     public static final String UNIX_GRADLE_COMMAND = "gradle";

--- a/src/main/java/hudson/plugins/gradle/GradleInstallation.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallation.java
@@ -36,7 +36,6 @@ public class GradleInstallation
         extends ToolInstallation
         implements EnvironmentSpecific<GradleInstallation>, NodeSpecific<GradleInstallation>, Serializable {
 
-    private static final long serialVersionUID = -1875114350592080381L;
     public static final String UNIX_GRADLE_COMMAND = "gradle";
     public static final String WINDOWS_GRADLE_COMMAND = "gradle.bat";
     public static final String UNIX_GRADLE_WRAPPER_COMMAND = "gradlew";
@@ -76,8 +75,6 @@ public class GradleInstallation
     public String getExecutable(final Launcher launcher) throws IOException, InterruptedException {
         final File exe = launcher.getChannel().call(new MasterToSlaveCallable<File, IOException>() {
 
-            private static final long serialVersionUID = 5572701806697595613L;
-
             @Override
             public File call() throws IOException {
                 return getExeFile();
@@ -85,8 +82,6 @@ public class GradleInstallation
         });
 
         final boolean existis = launcher.getChannel().call(new MasterToSlaveCallable<Boolean, IOException>() {
-
-            private static final long serialVersionUID = 5572701806697595613L;
 
             @Override
             public Boolean call() throws IOException {

--- a/src/main/java/hudson/plugins/gradle/GradleInstallationProvider.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallationProvider.java
@@ -10,6 +10,6 @@ public interface GradleInstallationProvider {
     /**
      * Provides all available {@link GradleInstallation}.
      */
-    public abstract GradleInstallation[] getInstallations();
+    GradleInstallation[] getInstallations();
     
 }

--- a/src/main/java/hudson/plugins/gradle/GradleInstallationProvider.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallationProvider.java
@@ -1,0 +1,15 @@
+package hudson.plugins.gradle;
+
+/**
+ * Interface for providing {@link GradleInstallation} independent of build type.
+ * 
+ * @author Sönke Küper
+ */
+public interface GradleInstallationProvider {
+
+    /**
+     * Provides all available {@link GradleInstallation}.
+     */
+    public abstract GradleInstallation[] getInstallations();
+    
+}

--- a/src/main/java/hudson/plugins/gradle/GradleInstallationProvider.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallationProvider.java
@@ -2,8 +2,6 @@ package hudson.plugins.gradle;
 
 /**
  * Interface for providing {@link GradleInstallation} independent of build type.
- * 
- * @author Sönke Küper
  */
 public interface GradleInstallationProvider {
 

--- a/src/main/java/hudson/plugins/gradle/GradleStep.java
+++ b/src/main/java/hudson/plugins/gradle/GradleStep.java
@@ -1,0 +1,321 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.gradle;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import com.google.common.collect.ImmutableSet;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.JDK;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tools.ToolInstallation;
+import hudson.util.VariableResolver;
+import jenkins.model.Jenkins;
+
+/**
+ * The Gradle-Step for a jenkins pipeline.
+ * 
+ * Only contains the configuration, the execution is delegated to an {@link GradleExecution}.
+ * 
+ * @author Sönke Küper
+ */
+public class GradleStep extends Step implements GradleInstallationProvider, Serializable {
+
+    private static final long serialVersionUID = -8990886083758016221L;
+
+    private String switches;
+    private String tasks;
+    private String rootBuildScriptDir;
+    private String buildFile;
+    private String gradleName;
+    private boolean useWrapper;
+    private boolean makeExecutable;
+    private boolean useWorkspaceAsHome;
+    private String wrapperLocation;
+    private String systemProperties;
+    private String projectProperties;
+    private String jdkName;
+    private String logEncoding;
+    
+    @DataBoundConstructor
+    public GradleStep () {
+    }
+    
+    @Override
+    public GradleInstallation[] getInstallations() {
+        return ((GradleStepDescriptor) getDescriptor()).getInstallations();
+    }
+
+    @DataBoundSetter
+    public void setLogEncoding(String logEncoding) {
+        this.logEncoding = logEncoding;
+    }
+    
+    public String getLogEncoding() {
+        return logEncoding;
+    }
+    
+    public String getSwitches() {
+        return switches;
+    }
+
+    @DataBoundSetter
+    public void setSwitches(String switches) {
+        this.switches = switches;
+    }
+
+    public String getTasks() {
+        return tasks;
+    }
+
+    @DataBoundSetter
+    public void setTasks(String tasks) {
+        this.tasks = tasks;
+    }
+
+    public String getRootBuildScriptDir() {
+        return rootBuildScriptDir;
+    }
+
+    @DataBoundSetter
+    public void setRootBuildScriptDir(String rootBuildScriptDir) {
+        this.rootBuildScriptDir = rootBuildScriptDir;
+    }
+
+    public String getBuildFile() {
+        return buildFile;
+    }
+
+    @DataBoundSetter
+    public void setBuildFile(String buildFile) {
+        this.buildFile = buildFile;
+    }
+
+    public String getGradleName() {
+        return gradleName;
+    }
+
+    @DataBoundSetter
+    public void setGradleName(String gradleName) {
+        this.gradleName = gradleName;
+    }
+
+    public boolean isUseWrapper() {
+        return useWrapper;
+    }
+
+    @DataBoundSetter
+    public void setUseWrapper(boolean useWrapper) {
+        this.useWrapper = useWrapper;
+    }
+
+    public boolean isMakeExecutable() {
+        return makeExecutable;
+    }
+
+    @DataBoundSetter
+    public void setMakeExecutable(boolean makeExecutable) {
+        this.makeExecutable = makeExecutable;
+    }
+
+    public boolean isUseWorkspaceAsHome() {
+        return useWorkspaceAsHome;
+    }
+
+    @DataBoundSetter
+    public void setUseWorkspaceAsHome(boolean useWorkspaceAsHome) {
+        this.useWorkspaceAsHome = useWorkspaceAsHome;
+    }
+
+    public String getWrapperLocation() {
+        return wrapperLocation;
+    }
+
+    @DataBoundSetter
+    public void setWrapperLocation(String wrapperLocation) {
+        this.wrapperLocation = wrapperLocation;
+    }
+
+    public String getSystemProperties() {
+        return systemProperties;
+    }
+
+    @DataBoundSetter
+    public void setSystemProperties(String systemProperties) {
+        this.systemProperties = Util.fixEmptyAndTrim(systemProperties);
+    }
+
+    public String getProjectProperties() {
+        return projectProperties;
+    }
+
+    @DataBoundSetter
+    public void setProjectProperties(String projectProperties) {
+        this.projectProperties = projectProperties;
+    }
+
+    /**
+     * Sets the Java installation to use
+     * @param jdkName the path of the jdk to use
+     */
+    @DataBoundSetter
+    public void setJdkName (String jdkName) {
+        this.jdkName = Util.fixEmpty(jdkName);
+    }
+    
+    public String getJdkName () {
+        return jdkName;
+    }
+    
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new SynchronousNonBlockingStepExecution<Void>(context) {
+
+            private static final long serialVersionUID = -8287401590137690657L;
+
+            @Override
+            protected Void run() throws Exception {
+                this.getContext()
+                    .get(FlowNode.class)
+                    .addAction(
+                        new LabelAction("Executing gradle build: " + tasks)
+                    );
+                
+                EnvVars env = getContext().get(EnvVars.class);
+                TaskListener listener = getContext().get(TaskListener.class);
+                if (jdkName != null) {
+                    JDK javaInstallation = Jenkins.getActiveInstance().getJDK(jdkName);
+                    if (javaInstallation == null) {
+                        listener.getLogger().printf("[Gradle] Java Installation '%s' not found. Defaulting to system installation. %n", jdkName);
+                    } else {
+                        listener.getLogger().printf("[Gradle] Java Installation found. Using '%s' %n", javaInstallation.getName());
+                        env.put("JAVA_HOME", javaInstallation.getHome());
+                    }
+                }
+                
+                boolean success = new GradleExecution(
+                    switches, 
+                    tasks, 
+                    rootBuildScriptDir, 
+                    buildFile,
+                    gradleName, 
+                    useWrapper, 
+                    makeExecutable, 
+                    useWorkspaceAsHome,
+                    wrapperLocation, 
+                    systemProperties,
+                    false, 
+                    projectProperties, 
+                    false,
+                    GradleStep.this,
+                    logEncoding
+                ).performTask(
+                    false, 
+                    getContext().get(Run.class), 
+                    getContext().get(Launcher.class),
+                    listener,
+                    getContext().get(FilePath.class),
+                    getContext().get(FilePath.class),
+                    new VariableResolver.ByMap<>(env),
+                    env,
+                    Collections.<String, String>emptyMap()
+                );
+                
+                if (!success) {
+                    throw new Exception("Gradle execution finished with failure. See log for further details.");
+                }
+                
+                return null;
+            }
+        };
+    }
+    
+    @Extension
+    public static final class GradleStepDescriptor extends StepDescriptor {
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, FilePath.class, TaskListener.class, EnvVars.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "gradle";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Executes a gradle build.";
+        }
+
+        @Override
+        public boolean takesImplicitBlockArgument() {
+            return false;
+        }
+
+        /**
+         * Obtains the {@link GradleInstallation.DescriptorImpl} instance.
+         */
+        public GradleInstallation[] getInstallations() {
+            GradleInstallation.DescriptorImpl gradleDescriptor = ToolInstallation.all().get(GradleInstallation.DescriptorImpl.class);
+            if (gradleDescriptor == null) {
+                return new GradleInstallation[0];
+            } else {
+                return gradleDescriptor.getInstallations();
+            }
+        }
+
+        /**
+         * Obtains the {@link GradleInstallation.DescriptorImpl} instance.
+         */
+        public JDK[] getJdkInstallations() {
+            JDK.DescriptorImpl jdkDescriptor = ToolInstallation.all().get(JDK.DescriptorImpl.class);
+            if (jdkDescriptor == null) {
+                return new JDK[0];
+            } else {
+                return jdkDescriptor.getInstallations();
+            }
+        }
+    }
+    
+}

--- a/src/main/java/hudson/plugins/gradle/GradleStep.java
+++ b/src/main/java/hudson/plugins/gradle/GradleStep.java
@@ -1,26 +1,3 @@
-/*
- * The MIT License
- *
- * Copyright (c) 2017, CloudBees, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 package hudson.plugins.gradle;
 
 import java.io.Serializable;
@@ -29,7 +6,6 @@ import java.util.Set;
 
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;

--- a/src/main/resources/hudson/plugins/gradle/Gradle/help-logEncoding.html
+++ b/src/main/resources/hudson/plugins/gradle/Gradle/help-logEncoding.html
@@ -1,0 +1,3 @@
+<div>
+    Specifies the log encoding of gradle build log. If not set encoding of jenkins build log is used.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/config.jelly
@@ -34,16 +34,8 @@
             <f:textarea/>
         </f:entry>
 
-        <f:entry title="${%Pass all job parameters as System properties}" field="passAllAsSystemProperties">
-            <f:checkbox default="false"/>
-        </f:entry>
-
         <f:entry field="projectProperties" title="${%Project properties}">
             <f:textarea/>
-        </f:entry>
-
-        <f:entry title="${%Pass all job parameters as Project properties}" field="passAllAsProjectProperties">
-            <f:checkbox default="false"/>
         </f:entry>
 
         <f:entry title="${%Root Build script}" field="rootBuildScriptDir">
@@ -58,13 +50,22 @@
         ">
             <f:textbox/>
         </f:entry>
-
+                
         <f:entry title="${%Log Encoding}" field="logEncoding">
             <f:textbox/>
         </f:entry>
 
         <f:entry title="${%Force GRADLE_USER_HOME to use workspace}" field="useWorkspaceAsHome">
             <f:checkbox default="false"/>
+        </f:entry>
+                
+        <f:entry title="${%Jdk Version}" field="jdkName">
+            <select class="setting-input" name="jdkName">
+                <option value="">(Default)</option>
+                <j:forEach var="inst" items="${descriptor.jdkInstallations}">
+                    <f:option selected="${inst.name==instance.jdkName}">${inst.name}</f:option>
+                </j:forEach>
+            </select>
         </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-buildFile.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-buildFile.html
@@ -1,0 +1,3 @@
+<div>
+    If your gradle build script is not named build.gradle, specify the gradle build name script.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-jdkName.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-jdkName.html
@@ -1,0 +1,3 @@
+<div>
+    Specifies the JDK Installation to use. If set the JAVA_HOME environment variable will be set inside the block.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-logEncoding.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-logEncoding.html
@@ -1,0 +1,3 @@
+<div>
+    Specifies the log encoding of gradle build log. If not set encoding of jenkins build log is used.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-passAsProperties.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-passAsProperties.html
@@ -1,0 +1,5 @@
+<p>
+    Jenkins job parameters can be passed to Gradle either as Java system properties (<tt>-D</tt>), or as Gradle
+    properties (<tt>-P</tt>). Using properties has the advantage that job parameters are directly accessible in the
+    Gradle DSL, e.g. <tt>project.hasProperty(...)</tt>.
+</p>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-rootBuildScriptDir.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-rootBuildScriptDir.html
@@ -1,0 +1,5 @@
+<div>
+    If your workspace has the top-level build.gradle in somewhere other than the module root directory, specify the path
+    (relative to the module root) here,
+    such as ${workspace}/parent/ instead of just ${workspace}. If left empty, defaults to build.gradle
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-switches.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-switches.html
@@ -1,0 +1,3 @@
+<div>
+    Specify a list of Gradle switches to be invoked, or leave it empty.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-tasks.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-tasks.html
@@ -1,0 +1,3 @@
+<div>
+    Specify a list of Gradle tasks to be invoked.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-useWorkspaceAsHome.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-useWorkspaceAsHome.html
@@ -1,0 +1,5 @@
+<p>
+    Gradle will write to <tt>$HOME/.gradle</tt> by default for <tt>GRADLE_USER_HOME</tt>.
+    For a multi-executor slave in Jenkins, setting the environment variable localized files to the workspace avoid
+    collisions accessing gradle cache.
+</p>

--- a/src/main/resources/hudson/plugins/gradle/GradleStep/help-wrapperLocation.html
+++ b/src/main/resources/hudson/plugins/gradle/GradleStep/help-wrapperLocation.html
@@ -1,0 +1,8 @@
+<div>
+    By default, the Gradle plugin tries to locate the wrapper executable (gradlew on Unix and gradlew.exe on Windows)
+    next to the build script. If it
+    is not there it will look in the workspace root.
+    If your workspace has the wrapper somewhere else, specify the path
+    to the directory (relative to workspace) containing the wrapper executable here,
+    such as parent instead of just ${workspace}/parent.
+</div>

--- a/src/test/java/hudson/plugins/gradle/GradleStepWorkflowTest.java
+++ b/src/test/java/hudson/plugins/gradle/GradleStepWorkflowTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.gradle;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.ToolInstallations;
+
+import hudson.model.Result;
+
+/**
+ * Tests the Gradle Build step in an Jenkins Pipeline.
+ *
+ * @author Sönke Küper
+ */
+@SuppressWarnings("nls")
+public class GradleStepWorkflowTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private final String build_gradle = "writeFile(file:'build.gradle', text:'defaultTasks \\\'hello\\\'\\ntask hello << { println \\\'Hello\\\' }') \n";
+
+    @Test
+    public void testStepDefaultTools() throws Exception {
+        final String name = ToolInstallations.configureDefaultGradle(this.folder).getName();
+        final WorkflowJob p1 = this.j.jenkins.createProject(WorkflowJob.class, "FakeProject");
+        p1.setDefinition(new CpsFlowDefinition(
+            "node {\n" +
+            this.build_gradle +
+            "  gradle gradleName: '" + name + "'\n" +
+            "}", false));
+        final WorkflowRun r = p1.scheduleBuild2(0).get();
+        this.j.assertBuildStatusSuccess(r);
+    }
+
+    @Test
+    public void testGradleErrorFailsBuild() throws Exception {
+        final String name = ToolInstallations.configureDefaultGradle(this.folder).getName();
+        final WorkflowJob p1 = this.j.jenkins.createProject(WorkflowJob.class, "FakeProject");
+        p1.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                this.build_gradle +
+                "  gradle gradleName: '" + name + "', tasks: 'unknownTask'\n" +
+                "}", false));
+        final WorkflowRun r = p1.scheduleBuild2(0).get();
+        this.j.assertBuildStatus(Result.FAILURE, r);
+    }
+
+    @Test
+    public void testStepWithConfiguredGradle() throws Exception {
+        final String name = ToolInstallations.configureDefaultGradle(this.folder).getName();
+        final WorkflowJob p1 = this.j.jenkins.createProject(WorkflowJob.class, "FakeProject");
+        p1.setDefinition(new CpsFlowDefinition(
+            "node {\n" +
+            this.build_gradle +
+            "  gradle gradleName: '" + name + "', switches: '-v'\n" +
+            "}",
+            false));
+        final WorkflowRun r = p1.scheduleBuild2(0).get();
+        this.j.assertBuildStatusSuccess(r);
+        assertTrue(r.getLog(), r.getLog().contains("Gradle 2.13")); // version bundled in jenkins-test-harness-tools
+    }
+
+    @Test
+    public void testConsoleLogAnnotation () throws Exception {
+        final String name = ToolInstallations.configureDefaultGradle(this.folder).getName();
+        final WorkflowJob p1 = this.j.jenkins.createProject(WorkflowJob.class, "FakeProject");
+        p1.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                "writeFile(file:'build.gradle', text:'defaultTasks \\\'bird\\\'\\ntask bird << { println \\\'chirp\\\' }') \n" +
+                "  gradle gradleName: '" + name + "'\n" +
+                "}", false));
+        final WorkflowRun r = p1.scheduleBuild2(0).get();
+
+        final StringWriter log = new StringWriter();
+        r.getLogText().writeHtmlTo(0, log);
+        assertTrue(log.toString(), log.toString().contains("<b class=gradle-task>bird"));
+    }
+}


### PR DESCRIPTION
Hey,
i've now put some more work on a real gradle pipeline step. This makes it **much** easier and comfortable running a gradle build in an jenkins pieline.

You are now able to run a gradle build using a predefined gradle with just this little pipeline
`node{
    gradle gradleName: 'gradle-4.10.2', tasks: 'clean build'
}`

I've implemented this in our test environment and saved a lot of code in our pipeline script for handling environment variables like PATH and JAVA_HOME catching stderr of gradle logs and so on.

It would be great to get this in so we could use this in our productive environment.

Basically i've moved the main logic of executing gradle into GradleExecution.java so it can now be used by pipeline and freestyle builds as well.
