### PR TITLE
[JENKINS-53575] Configuration-as-Code compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ plugins {
   id 'codenarc'
 }
 
+apply from: "$rootDir/gradle/jcascTest.gradle"
+
 group = 'org.jenkins-ci.plugins'
 description = 'This plugin adds Gradle support to Jenkins'
 
@@ -18,7 +20,7 @@ if (ciBuild) {
 
 jenkinsPlugin {
   // Version of Jenkins core this plugin depends on.
-  coreVersion = '2.60.3'
+  coreVersion = '1.642.1'
 
   // Human-readable name of plugin.
   displayName = 'Gradle Plugin'
@@ -61,9 +63,8 @@ dependencies {
 
   signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
-  testCompile 'org.spockframework:spock-core:1.2-groovy-2.4', { exclude module: 'groovy-all' }
+  testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
   jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.44@jar'
-  jenkinsTest 'io.jenkins:configuration-as-code:1.4'
 }
 
 if (project.hasProperty('maxParallelForks')) {
@@ -127,4 +128,5 @@ tasks.withType(AbstractPublishToMaven) {
   dependsOn checkArchiveManifests
 }
 
-defaultTasks 'test', 'jpi'
+defaultTasks.add 'test'
+defaultTasks.add 'jpi'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ if (ciBuild) {
 
 jenkinsPlugin {
   // Version of Jenkins core this plugin depends on.
-  coreVersion = '1.642.1'
+  coreVersion = '2.60.3'
 
   // Human-readable name of plugin.
   displayName = 'Gradle Plugin'
@@ -61,8 +61,9 @@ dependencies {
 
   signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
-  testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
+  testCompile 'org.spockframework:spock-core:1.2-groovy-2.4', { exclude module: 'groovy-all' }
   jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.44@jar'
+  jenkinsTest 'io.jenkins:configuration-as-code:1.4'
 }
 
 if (project.hasProperty('maxParallelForks')) {

--- a/gradle/jcascTest.gradle
+++ b/gradle/jcascTest.gradle
@@ -1,0 +1,33 @@
+sourceSets {
+  test {
+    groovy.exclude '**/ConfigurationAsCodeTest.groovy'
+  }
+  jcascTest {
+    groovy.srcDirs sourceSets.test.groovy.srcDirs
+    resources.srcDirs sourceSets.test.resources.srcDirs
+  }
+}
+
+dependencies {
+  jcascTestImplementation 'org.jenkins-ci.main:jenkins-war:2.60.3'
+  jcascTestImplementation 'org.spockframework:spock-core:1.2-groovy-2.4', { exclude module: 'groovy-all' }
+  jcascTestImplementation 'io.jenkins:configuration-as-code:1.4'
+  jcascTestImplementation 'io.jenkins:configuration-as-code:1.4@jar'
+
+  jcascTestImplementation sourceSets.main.output
+  jcascTestImplementation sourceSets.test.output
+
+  jcascTestImplementation configurations.implementation
+  jcascTestImplementation configurations.testImplementation
+}
+
+task jcascTest(type: Test) {
+  description = 'Runs Configuration-as-Code tests (requires Jenkins >=2.60.3).'
+  include '**/ConfigurationAsCodeTest.class'
+  testClassesDirs = sourceSets.jcascTest.output.classesDirs
+  classpath = sourceSets.jcascTest.runtimeClasspath
+}
+
+check.dependsOn jcascTest
+
+defaultTasks.add 'jcascTest'

--- a/src/main/java/hudson/plugins/gradle/GradleInstallation.java
+++ b/src/main/java/hudson/plugins/gradle/GradleInstallation.java
@@ -13,11 +13,11 @@ import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
+import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -44,7 +44,7 @@ public class GradleInstallation extends ToolInstallation
     }
 
     private static String launderHome(String home) {
-        if (home.endsWith("/") || home.endsWith("\\")) {
+        if (home != null && (home.endsWith("/") || home.endsWith("\\"))) {
             // see https://issues.apache.org/bugzilla/show_bug.cgi?id=26947
             // Ant doesn't like the trailing slash, especially on Windows
             return home.substring(0, home.length() - 1);
@@ -98,9 +98,6 @@ public class GradleInstallation extends ToolInstallation
         public DescriptorImpl() {
         }
 
-        @Inject
-        private Gradle.DescriptorImpl gradleDescriptor;
-
         @Override
         public String getDisplayName() {
             return Messages.installer_displayName();
@@ -111,17 +108,20 @@ public class GradleInstallation extends ToolInstallation
             return Collections.singletonList(new GradleInstaller(null));
         }
 
-        // for compatibility reasons, the persistence is done by GradleBuilder.DescriptorImpl
+        // for compatibility reasons, the persistence is done by Gradle.DescriptorImpl
 
         @Override
         public GradleInstallation[] getInstallations() {
-            return gradleDescriptor.getInstallations();
+            return getGradleDescriptor().getInstallations();
         }
 
         @Override
         public void setInstallations(GradleInstallation... installations) {
-            gradleDescriptor.setInstallations(installations);
+            getGradleDescriptor().setInstallations(installations);
         }
 
+        private static Gradle.DescriptorImpl getGradleDescriptor() {
+            return Jenkins.getActiveInstance().getDescriptorByType(Gradle.DescriptorImpl.class);
+        }
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/ConfigurationAsCodeTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/ConfigurationAsCodeTest.groovy
@@ -1,0 +1,56 @@
+package hudson.plugins.gradle
+
+import hudson.tools.InstallSourceProperty
+import io.jenkins.plugins.casc.ConfigurationAsCode
+import io.jenkins.plugins.casc.snakeyaml.Yaml
+
+class ConfigurationAsCodeTest extends AbstractIntegrationTest {
+
+    def 'import configuration'() {
+        given:
+        def configurationUrl = getClass().getResource(getClass().getSimpleName() + '/configuration-as-code.yml').toString()
+
+        when:
+        ConfigurationAsCode.get().configure(configurationUrl)
+
+        then:
+        def installations = j.jenkins.getDescriptorByType(GradleInstallation.DescriptorImpl).getInstallations()
+
+        installations[0].name == 'gradle-5.0'
+        installations[0].home == '/opt/gradle/gradle-5.0'
+        installations[0].properties == []
+
+        installations[1].name == 'gradle-4.0'
+        installations[1].home == null
+        installations[1].properties[0].class == InstallSourceProperty
+        installations[1].properties[0].installers[0].class == GradleInstaller
+        installations[1].properties[0].installers[0].id == '4.0'
+        installations[1].properties[0].installers.size() == 1
+        installations[1].properties.size() == 1
+
+        installations.size() == 2
+    }
+
+    def 'export configuration'() {
+        given:
+        gradleInstallationRule.addInstallations(
+            new GradleInstallation('gradle-5.0', '/opt/gradle/gradle-5.0', null),
+            new GradleInstallation('gradle-4.0', null, [new InstallSourceProperty([new GradleInstaller('4.0')])]),
+        )
+
+        when:
+        def outputStream = new ByteArrayOutputStream()
+        ConfigurationAsCode.get().export(outputStream)
+
+        then:
+        def inputStream = new ByteArrayInputStream(outputStream.toByteArray())
+        def configuration = new Yaml().load(inputStream)
+
+        configuration.tool.gradle == [
+            installations: [
+                [name: 'gradle-5.0', home: '/opt/gradle/gradle-5.0'],
+                [name: 'gradle-4.0', properties: [[installSource: [installers: [[gradleInstaller: [id: '4.0']]]]]]],
+            ]
+        ]
+    }
+}

--- a/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -7,6 +7,7 @@ import org.junit.runner.Description
 import org.jvnet.hudson.test.JenkinsRule
 
 class GradleInstallationRule extends TestWatcher {
+
     static {
         System.setProperty("hudson.model.DownloadService.noSignatureCheck", "true")
     }
@@ -35,17 +36,16 @@ class GradleInstallationRule extends TestWatcher {
     }
 
     void addInstallations(String... installationNames) {
-        def gradleInstallationDescriptor = j.jenkins.getDescriptorByType(hudson.plugins.gradle.GradleInstallation.DescriptorImpl)
-
-        GradleInstallation[] installations = new GradleInstallation[installationNames.size()]
-
-        for (int i = 0; i < installationNames.size(); i++) {
-            String name = installationNames[i]
-            installations[i] = new GradleInstallation(name, "", [new InstallSourceProperty([new GradleInstaller(gradleVersion)])])
+        def installations = installationNames.collect{ name ->
+            new GradleInstallation(name, "", [new InstallSourceProperty([new GradleInstaller(gradleVersion)])])
         }
 
-        gradleInstallationDescriptor.setInstallations(installations)
+        addInstallations(*installations)
+    }
 
+    void addInstallations(GradleInstallation... installations) {
+        def gradleInstallationDescriptor = j.jenkins.getDescriptorByType(hudson.plugins.gradle.GradleInstallation.DescriptorImpl)
+        gradleInstallationDescriptor.setInstallations(installations)
         assert gradleInstallationDescriptor.getInstallations()
     }
 }

--- a/src/test/resources/hudson/plugins/gradle/ConfigurationAsCodeTest/configuration-as-code.yml
+++ b/src/test/resources/hudson/plugins/gradle/ConfigurationAsCodeTest/configuration-as-code.yml
@@ -1,0 +1,12 @@
+---
+tool:
+  gradle:
+    installations:
+    - name: "gradle-5.0"
+      home: "/opt/gradle/gradle-5.0"
+    - name: "gradle-4.0"
+      properties:
+      - installSource:
+          installers:
+          - gradleInstaller:
+              id: "4.0"


### PR DESCRIPTION
This fixes problems with JCasC for configuration import & export.

Also see the respective issue in JCasC - jenkinsci/configuration-as-code-plugin/issues/460.