### PR TITLE
Fix server task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,13 +58,12 @@ sourceCompatibility = '1.7'
 
 dependencies {
   compile 'org.jenkins-ci.lib:dry-run-lib:0.1'
-  compileOnly 'org.jenkins-ci:symbol-annotation:1.3'
-  jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.3@jar'
+  jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.3'
 
   signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 
   testCompile 'org.spockframework:spock-core:0.7-groovy-1.8'
-  jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.44@jar'
+  jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.44'
 }
 
 if (project.hasProperty('maxParallelForks')) {


### PR DESCRIPTION
Running `gradle server` failed with the following error before this change:
> Failed Loading plugin gradle
> java.io.IOException: Dependency structs (1.3) doesn't exist

Transitive plugin dependency resolution has been fixed in org.jenkins-ci.jpi 0.23.1.
Excerpt from CHANGELOG: "plugin dependencies must not longer be specified with artifact only notation"

This jpi plugin fix can now be used to declare the dependencies without the artifact only notation. As a result the structs plugin is also provided correctly as plugin for the server task.