### PR TITLE
Expose build scan action via Jenkins API

### DIFF
--- a/src/main/java/hudson/plugins/gradle/BuildScanAction.java
+++ b/src/main/java/hudson/plugins/gradle/BuildScanAction.java
@@ -1,11 +1,14 @@
 package hudson.plugins.gradle;
 
 import hudson.model.Action;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@ExportedBean
 public class BuildScanAction implements Action {
 
     // Backward compatibility for old plugins versions which created an action per-scan
@@ -32,6 +35,7 @@ public class BuildScanAction implements Action {
         scanUrls.add(scanUrl);
     }
 
+    @Exported
     public List<String> getScanUrls() {
         return Collections.unmodifiableList(scanUrls);
     }


### PR DESCRIPTION
This PR adds the appropriate annotations to `BuildScanAction` so that this information is available via the Jenkins REST APIs. This allows clients that hit the API to also get access to build scans published by a given Job w/o having to manually parse the console log.