### PR TITLE
Support variables in build file location

### DIFF
--- a/src/main/java/hudson/plugins/gradle/Gradle.java
+++ b/src/main/java/hudson/plugins/gradle/Gradle.java
@@ -380,8 +380,9 @@ public class Gradle extends Builder {
             wrapperLocationNormalized = Util.replaceMacro(wrapperLocationNormalized.trim(), resolver);
             return ImmutableList.of(new FilePath(moduleRoot, wrapperLocationNormalized));
         } else if (buildFile != null && !buildFile.isEmpty()) {
+            String buildFileNormalized = Util.replaceMacro(buildFile.trim(), resolver);
             // Check if the target project is located not at the root dir
-            FilePath parentOfBuildFile = new FilePath(normalizedRootBuildScriptDir == null ? moduleRoot : normalizedRootBuildScriptDir, buildFile).getParent();
+            FilePath parentOfBuildFile = new FilePath(normalizedRootBuildScriptDir == null ? moduleRoot : normalizedRootBuildScriptDir, buildFileNormalized).getParent();
             if (parentOfBuildFile != null && !parentOfBuildFile.equals(moduleRoot)) {
                 return ImmutableList.of(parentOfBuildFile, moduleRoot);
             }


### PR DESCRIPTION
Resolve variables for **buildFile** in **getPossibleWrapperLocations** method (same as in **Gradle.perform** method)
Now it is not possible to calculate gradle wrapper location if **buildFile** contains env variables.