### PR TITLE
Return build scans list when calling findBuildScans()

### DIFF
--- a/src/main/java/hudson/plugins/gradle/BuildScanPublisher.java
+++ b/src/main/java/hudson/plugins/gradle/BuildScanPublisher.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -25,7 +26,7 @@ public class BuildScanPublisher extends Step {
         return new Execution(context);
     }
 
-    static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+    static class Execution extends SynchronousNonBlockingStepExecution<List<String>> {
         private static final long serialVersionUID = 1L;
 
         protected Execution(@Nonnull StepContext context) {
@@ -33,7 +34,7 @@ public class BuildScanPublisher extends Step {
         }
 
         @Override
-        protected Void run() throws Exception {
+        protected List<String> run() throws Exception {
             Run run = getContext().get(Run.class);
             BuildScanLogScanner scanner = new BuildScanLogScanner(new DefaultBuildScanPublishedListener(run));
             try (
@@ -42,7 +43,8 @@ public class BuildScanPublisher extends Step {
             ) {
                 lines.forEach(scanner::scanLine);
             }
-            return null;
+
+            return run.getAction(BuildScanAction.class).getScanUrls();
         }
     }
 

--- a/src/main/java/hudson/plugins/gradle/BuildScanPublisher.java
+++ b/src/main/java/hudson/plugins/gradle/BuildScanPublisher.java
@@ -12,6 +12,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -43,8 +45,11 @@ public class BuildScanPublisher extends Step {
             ) {
                 lines.forEach(scanner::scanLine);
             }
-
-            return run.getAction(BuildScanAction.class).getScanUrls();
+            BuildScanAction action = run.getAction(BuildScanAction.class);
+            if (action != null) {
+                return action.getScanUrls();
+            }
+            return Collections.emptyList();
         }
     }
 


### PR DESCRIPTION
Currently there is no way to retrieve the build scan URLs on post actions in order to send them to a chat application.

Before merging would love to know how to add a `BuildScanIntegrationTest` to verify my changes.