### PR TITLE
Reference the Release Drafter docs from GitHub Actions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,5 @@
+# Automates creation of Release Drafts using Release Drafter
+# More Info: https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 name: Release Management
 
 on:


### PR DESCRIPTION
GitHub Actions are enabled now, but they did not pick up the workflow definition automatically.
Looks like we need a commit to trigger the workflow creation. 
