### PR TITLE
Apply workaround for issue #301 in Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: onenashev/jenkins-release-drafter@v5.2.0-jenkins-2
+      - uses: oleg-nenashev/jenkins-release-drafter@v5.2.0-jenkins-2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: toolmantim/release-drafter@v5.2.0
+      - uses: onenashev/jenkins-release-drafter@v5.2.0-jenkins-2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Going nuclear by trying a boilerplate fork of Release Drafter for GitHub Actions. https://github.com/oleg-nenashev/jenkins-release-drafter once we are happy with the change, we can get it upstreamed

https://github.com/toolmantim/release-drafter/issues/301

