### PR TITLE
Use the "test-retry" plugin to handle flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import java.util.zip.ZipFile
 
 plugins {
   id 'com.gradle.build-scan' version '2.4.2'
+  id 'org.gradle.test-retry' version '1.0.0'
   id 'org.jenkins-ci.jpi' version '0.33.0'
   id 'ru.vyarus.animalsniffer' version '1.5.0'
   id 'findbugs'
@@ -137,6 +138,10 @@ test {
   systemProperties['hudson.model.DownloadService.noSignatureCheck'] = 'true'
   ignoreFailures = ciBuild
   maxParallelForks = project.maxParallelForks
+  retry {
+    maxRetries = 1
+    maxFailures = 10
+  }
 }
 
 def checkArchiveManifest(File archive) {


### PR DESCRIPTION
see https://github.com/gradle/test-retry-gradle-plugin

On ci.jenkins.io some tests are flaky. They sometimes run into a timeout when connecting to remote systems.

Question: Should the retry mechanism only be enabled on CI?
At least for Maven based plugins it is always enabled - see [here](https://github.com/jenkinsci/plugin-pom/blob/plugin-3.55/pom.xml#L1128-L1138).
If have no idea how disabling this mechanism can be implemented when only specific tests are run (as it is implemented for Maven plugins).