### PR TITLE
Remove line length limit for build scan message

### DIFF
--- a/src/main/java/hudson/plugins/gradle/BuildScanLogScanner.java
+++ b/src/main/java/hudson/plugins/gradle/BuildScanLogScanner.java
@@ -9,8 +9,6 @@ public class BuildScanLogScanner {
     private static final Pattern BUILD_SCAN_PATTERN = Pattern.compile("Publishing (build scan|build information)\\.\\.\\.");
     private static final Pattern URL_PATTERN = Pattern.compile("https?://\\S*");
 
-    public static final int MAX_PUBLISHED_MESSAGE_LENGTH = 70;
-
     public BuildScanLogScanner(BuildScanPublishedListener listener) {
         this.listener = listener;
     }
@@ -25,7 +23,7 @@ public class BuildScanLogScanner {
                 listener.onBuildScanPublished(buildScanUrl);
             }
         }
-        if (line.length() < MAX_PUBLISHED_MESSAGE_LENGTH && BUILD_SCAN_PATTERN.matcher(line).find()) {
+        if (BUILD_SCAN_PATTERN.matcher(line).find()) {
             linesSinceBuildScanPublishingMessage = 0;
         }
 

--- a/src/main/java/hudson/plugins/gradle/GradleConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/gradle/GradleConsoleAnnotator.java
@@ -13,23 +13,23 @@ import java.nio.charset.Charset;
  */
 public class GradleConsoleAnnotator extends LineTransformationOutputStream {
 
+    private static final int MAX_LINE_LENGTH = 500;
+
     private final OutputStream out;
     private final Charset charset;
     private final boolean annotateGradleOutput;
-    private final int maxLineLength;
     private final BuildScanLogScanner buildScanLogScanner;
 
     public GradleConsoleAnnotator(OutputStream out, Charset charset, boolean annotateGradleOutput, BuildScanPublishedListener buildScanListener) {
         this.out = out;
         this.charset = charset;
         this.annotateGradleOutput = annotateGradleOutput;
-        this.maxLineLength = annotateGradleOutput ? 500 : BuildScanLogScanner.MAX_PUBLISHED_MESSAGE_LENGTH;
         this.buildScanLogScanner = new BuildScanLogScanner(buildScanListener);
     }
 
     @Override
     protected void eol(byte[] b, int len) throws IOException {
-        if (len < maxLineLength) { // Don't parse too long lines
+        if (len < MAX_LINE_LENGTH) { // Don't parse too long lines
             String line = charset.decode(ByteBuffer.wrap(b, 0, len)).toString();
 
             // trim off CR/LF from the end


### PR DESCRIPTION
In some cases, like when a few plugins are applied, the line length of the build scan published message can get large. In that case, the build scan URL has not been detected.

This PR removes the line length limit completely. The performance impact of scanning very long lines should be small, given that the full line already has been read into memory.