### PR TITLE
Upgrade jpi plugin to 0.43.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.util.zip.ZipFile
 
 plugins {
   id 'org.gradle.test-retry' version '1.3.1'
-  id 'org.jenkins-ci.jpi' version '0.39.0'
+  id 'org.jenkins-ci.jpi' version '0.43.0'
   id 'ru.vyarus.animalsniffer' version '1.5.4'
   id 'com.github.spotbugs' version '3.0.0'
   id 'codenarc'

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
   testImplementation 'org.jenkins-ci.plugins:pipeline-stage-step:2.3'
   testImplementation 'org.spockframework:spock-core:1.2-groovy-2.4'
 
+  testRuntimeOnly "org.jenkins-ci.main:jenkins-war:${coreBaseVersion}"
+
   jenkinsServer 'org.jenkins-ci.plugins:git'
 }
 


### PR DESCRIPTION
See https://github.com/jenkinsci/gradle-jpi-plugin/issues/190 why the changes to `testRuntimeOnly` are necessary.