### PR TITLE
Find build scans in console logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,3 @@
 buildPluginWithGradle()
+
+findBuildScans()


### PR DESCRIPTION
So the links to the build scans show up on the build page.