### PR TITLE
Allow Build Scan publishing without changing project configurations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,8 @@ http://www.gradle.org/[Gradle] is managed as another tool inside Jenkins (the sa
 
 It also allows detecting https://gradle.com/build-scans/[Build Scans] in arbitrary console logs, for Maven and Gradle builds and display them in the Jenkins UI.
 
+The plugin also allows for injecting Build Scans into both Maven and Gradle builds by setting some environment variables, see link:#_injecting_build_scans[Injecting Build Scans].
+
 In order to release this plugin have a look at link:RELEASING.md[here].
 
 == Configuration
@@ -85,6 +87,43 @@ There is also the `findBuildScans()` step, which finds the build scans in the co
 The `withGradle` wrapper should be used instead, since it also deals well with parallel output.
 
 image::find-build-scans.png[Find build scans,{thumbnail}]
+
+== Injecting Build Scans
+
+The plugin can be configured to inject Build Scans into any Gradle or Maven build that's running on the Jenkins server or any of its connected agents.
+
+=== How it works
+
+This feature works by installing scripts and Jars on each agent depending on the environment variable settings.
+
+If the `JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION` environment variable is present, injection is activated for Gradle builds.
+This causes an init script is installed in the user home of each connected agent.
+The init script is removed when the environment variable is removed, thus deactivating injection for Gradle builds.
+If the `JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_EXTENSION_VERSION` environment variable is present, injection is activated for Maven builds.
+This causes the Gradle Enterprise Maven Extension to be installed on each connected agent, and the `MAVEN_OPTS` environment variable will be modified so that each Maven process will load the extension.
+If the environment variable is removed again, the extension is deleted from all agents and the changes to `MAVEN_OPTS` are reverted.
+
+=== Configuration options
+
+The following table lists all available configuration options.
+
+.General variables
+|===
+|Environment variable|Build Tool|Description
+
+|JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL|Both|The URL of the Gradle Enterprise server to publish Build Scans to.
+|JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER|Both|Whether to allow publishing to a server with a self-signed certificate. Defaults to `false`.
+|JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_EXTENSION_VERSION|Maven|Enables injection for Maven builds.
+|JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION|Gradle|Enables injection for Gradle builds and defines which version of the https://plugins.gradle.org/plugin/com.gradle.enterprise[Gradle Enterprise Gradle plugin] to use.
+|JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION|Gradle|Defines which version of the https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin[Gradle Enterprise Gradle plugin] to use.
+|===
+
+In addition to the variables above you might want to set the `GRADLE_ENTERPRISE_ACCESS_KEY` variable if you're Gradle Enterprise server requires authentication for publishing Build Scans. Refer to the https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable[Gradle Enterprise Gradle plugin manual] and the https://docs.gradle.com/enterprise/maven-extension/#via_environment_variable[Gradle Enterprise Maven Extension manual] for more information.
+
+=== Limitations
+
+- The configuration is based on global environment variables and applies to all builds on the server and all connected agents.
+- Injecting Build Scans into Maven builds only works in `MAVEN_OPTS` is not set.
 
 == Roadmap
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ java {
   sourceCompatibility = 'VERSION_1_8'
 }
 
+configurations.create('includedLibs')
+
 dependencies {
   api platform("io.jenkins.tools.bom:bom-${coreBaseVersion}.x:${coreBomVersion}")
 
@@ -68,6 +70,9 @@ dependencies {
   implementation 'org.jenkins-ci.plugins.workflow:workflow-durable-task-step'
   implementation 'org.jenkins-ci.plugins.workflow:workflow-step-api'
 
+  includedLibs 'com.gradle:gradle-enterprise-maven-extension:1.14.2'
+  includedLibs 'com.gradle:common-custom-user-data-maven-extension:1.10.1'
+
   signature 'org.codehaus.mojo.signature:java18:1.0@signature'
 
   testImplementation 'org.jenkins-ci.main:jenkins-test-harness:2.56'
@@ -75,6 +80,13 @@ dependencies {
   testImplementation 'io.jenkins:configuration-as-code:1.4'
   testImplementation 'org.jenkins-ci.plugins:timestamper:1.8.10'
   testImplementation 'org.jenkins-ci.plugins:pipeline-stage-step:2.3'
+  testImplementation 'org.jenkins-ci.plugins:pipeline-maven:3.10.0'
+  testImplementation 'org.jenkins-ci.plugins:git:4.9.2:tests'
+  testImplementation 'org.jenkins-ci.plugins:git:4.9.2'
+  testImplementation 'org.jenkins-ci.plugins:scm-api:608.vfa_f971c5a_a_e9:tests'
+  testImplementation 'org.jenkins-ci.test:docker-fixtures:1.11'
+  testImplementation 'org.jenkins-ci.plugins:ssh-slaves:1.33.0'
+
   testImplementation 'org.spockframework:spock-core:1.2-groovy-2.4'
 
   testRuntimeOnly "org.jenkins-ci.main:jenkins-war:${coreBaseVersion}"
@@ -85,7 +97,7 @@ dependencies {
 if (project.hasProperty('maxParallelForks')) {
   project.maxParallelForks = Integer.valueOf(project.maxParallelForks, 10)
 } else {
-  ext.maxParallelForks = 3
+  ext.maxParallelForks = 1
 }
 
 animalsniffer {
@@ -120,8 +132,10 @@ test {
   ignoreFailures = gradle.ciBuild
   maxParallelForks = project.maxParallelForks
   retry {
-    maxRetries = 1
-    maxFailures = 10
+    if (gradle.ciBuild) {
+      maxRetries = 1
+      maxFailures = 10
+    }
   }
 }
 
@@ -165,3 +179,9 @@ task createWrapperZip(type: Zip) {
 }
 
 processTestResources.dependsOn(createWrapperZip)
+
+jar {
+  from(configurations.includedLibs) {
+    into("hudson/plugins/gradle/injection")
+  }
+}

--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanInjection.java
@@ -1,0 +1,19 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.EnvVars;
+import hudson.model.Node;
+
+public interface BuildScanInjection {
+
+    default String getEnv(EnvVars env, String key) {
+        return env != null ? env.get(key) : null;
+    }
+
+    default boolean isEnabled(EnvVars env) {
+        return getEnv(env, getActivationEnvironmentVariableName()) != null;
+    }
+
+    String getActivationEnvironmentVariableName();
+
+    void inject(Node node, EnvVars envGlobal, EnvVars envComputer);
+}

--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanInjectionListener.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanInjectionListener.java
@@ -1,0 +1,60 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Computer;
+import hudson.model.TaskListener;
+import hudson.slaves.ComputerListener;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+@Extension
+public class BuildScanInjectionListener extends ComputerListener {
+
+    private static final Logger LOGGER = Logger.getLogger(BuildScanInjectionListener.class.getName());
+
+    private final List<BuildScanInjection> injections = Arrays.asList(
+            new GradleBuildScanInjection(),
+            new MavenBuildScanInjection()
+    );
+
+    @Override
+    public void onOnline(Computer c, TaskListener listener) {
+        try {
+            EnvVars envGlobal = c.buildEnvironment(listener);
+            EnvVars envComputer = c.getEnvironment();
+
+            LOGGER.fine("onOnline " + c.getName());
+            inject(c, envGlobal, envComputer);
+        } catch (IOException | InterruptedException e) {
+            LOGGER.warning("Error processing scan injection - " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void onConfigurationChange() {
+        EnvironmentVariablesNodeProperty envProperty = Jenkins.get().getGlobalNodeProperties()
+                .get(EnvironmentVariablesNodeProperty.class);
+        EnvVars envGlobal = envProperty != null ? envProperty.getEnvVars() : null;
+
+        for (Computer c : Jenkins.get().getComputers()) {
+            try {
+                LOGGER.fine("onConfigurationChange " + c.getName());
+                final EnvVars envComputer = c.getEnvironment();
+                inject(c, envGlobal, envComputer);
+            } catch (IOException | InterruptedException e) {
+                LOGGER.warning("Error processing scan injection - " + e.getMessage());
+            }
+        }
+    }
+
+    private void inject(Computer c, EnvVars envGlobal, EnvVars envComputer) {
+        injections.forEach(injection -> injection.inject(c.getNode(), envGlobal, envComputer));
+    }
+
+}

--- a/src/main/java/hudson/plugins/gradle/injection/ClearMavenOpts.java
+++ b/src/main/java/hudson/plugins/gradle/injection/ClearMavenOpts.java
@@ -1,0 +1,52 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.EnvVars;
+import jenkins.security.MasterToSlaveCallable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ClearMavenOpts extends MasterToSlaveCallable<Void, RuntimeException> {
+
+    private final Set<String> keys;
+
+    public ClearMavenOpts(String... keys) {
+        this.keys = new HashSet<>(Arrays.asList(keys));
+    }
+
+    @Override
+    public Void call() throws RuntimeException {
+        String newMavenOpts = Optional.ofNullable(EnvVars.masterEnvVars.get("MAVEN_OPTS"))
+                .map(this::filterMavenOpts)
+                .orElse("");
+
+        if (newMavenOpts.isEmpty()) {
+            EnvVars.masterEnvVars.remove("MAVEN_OPTS");
+        } else {
+            EnvVars.masterEnvVars.put("MAVEN_OPTS", newMavenOpts);
+        }
+        return null;
+    }
+
+    /**
+     * Splits MAVEN_OPTS at each space and then removes all key value pairs that contain
+     * any of the keys we want to remove.
+     */
+    private String filterMavenOpts(String mavenOpts) {
+        return Arrays.stream(mavenOpts.split(" "))
+                .filter(this::shouldBeKept)
+                .collect(Collectors.joining(" "))
+                .trim();
+    }
+
+    /**
+     * Checks for a MAVEN_OPTS key value pair whether it contains none of the keys we're looking for.
+     * In other words if this segment none of the keys, this method returns true.
+     */
+    private boolean shouldBeKept(String seg) {
+        return keys.stream().noneMatch(seg::contains);
+    }
+}

--- a/src/main/java/hudson/plugins/gradle/injection/GradleBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleBuildScanInjection.java
@@ -1,0 +1,97 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.Node;
+import hudson.remoting.VirtualChannel;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+public class GradleBuildScanInjection implements BuildScanInjection {
+
+    private static final Logger LOGGER = Logger.getLogger(GradleBuildScanInjection.class.getName());
+
+    private static final String JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME = "JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME";
+
+    private static final String RESOURCE_INIT_SCRIPT_GRADLE = "scripts/init-script.gradle";
+    private static final String INIT_DIR = "init.d";
+    private static final String GRADLE_DIR = ".gradle";
+    private static final String GRADLE_INIT_FILE = "init-build-scan.gradle";
+
+    @Override
+    public String getActivationEnvironmentVariableName() {
+        return "JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION";
+    }
+
+    @Override
+    public void inject(Node node, EnvVars envGlobal, EnvVars envComputer) {
+        try {
+            String initScriptDirectory = getInitScriptDirectory(envGlobal, envComputer);
+
+            if (isEnabled(envGlobal)) {
+                copyInitScript(node.getChannel(), initScriptDirectory);
+            } else {
+                removeInitScript(node.getChannel(), initScriptDirectory);
+            }
+        } catch (IllegalStateException e) {
+            LOGGER.warning("Error: " + e.getMessage());
+        }
+    }
+
+    private String getInitScriptDirectory(EnvVars envGlobal, EnvVars envComputer) {
+        String homeOverride = getEnv(envGlobal, JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME);
+        if (homeOverride != null) {
+            return homeOverride + "/" + GRADLE_DIR + "/" + INIT_DIR;
+        } else {
+            String home = getEnv(envComputer, "HOME");
+            if(home == null){
+                throw new IllegalStateException("HOME is not set");
+            }
+            return home + "/" + GRADLE_DIR + "/" + INIT_DIR;
+        }
+    }
+
+    private void copyInitScript(VirtualChannel channel, String initScriptDirectory) {
+        try {
+            FilePath gradleInitScriptFile = getInitScriptFile(channel, initScriptDirectory);
+            if (!gradleInitScriptFile.exists()) {
+                FilePath gradleInitScriptDirectory = new FilePath(channel, initScriptDirectory);
+                if (!gradleInitScriptDirectory.exists()) {
+                    LOGGER.fine("create init script directory");
+                    gradleInitScriptDirectory.mkdirs();
+                }
+
+                LOGGER.fine("copy init script file");
+                gradleInitScriptFile.copyFrom(
+                        Objects.requireNonNull(BuildScanInjectionListener.class.getClassLoader().getResourceAsStream(RESOURCE_INIT_SCRIPT_GRADLE))
+                );
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void removeInitScript(VirtualChannel channel, String initScriptDirectory) {
+        try {
+            FilePath gradleInitScriptFile = getInitScriptFile(channel, initScriptDirectory);
+            if (gradleInitScriptFile.exists()) {
+                LOGGER.fine("delete init script file");
+                if (!gradleInitScriptFile.delete()) {
+                    throw new IllegalStateException("Error while deleting init script");
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private FilePath getInitScriptFile(VirtualChannel channel, String initScriptDirectory) {
+        if (initScriptDirectory == null) {
+            throw new IllegalStateException("init script directory is null");
+        }
+        return new FilePath(channel, initScriptDirectory + "/" + GRADLE_INIT_FILE);
+    }
+
+}

--- a/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
@@ -1,0 +1,116 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.Node;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MavenBuildScanInjection implements BuildScanInjection {
+
+    private static final String GE_MVN_LIB_NAME = "gradle-enterprise-maven-extension-1.14.2.jar";
+    private static final String CCUD_LIB_NAME = "common-custom-user-data-maven-extension-1.10.1.jar";
+    // Maven system properties passed on the CLI to a Maven build
+    private static final String GRADLE_ENTERPRISE_URL_PROPERTY_KEY = "gradle.enterprise.url";
+    private static final String GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY = "gradle.enterprise.allowUntrustedServer";
+    // Environment variables set in Jenkins Global configuration
+    private static final String GRADLE_SCAN_UPLOAD_IN_BACKGROUND_PROPERTY_KEY = "gradle.scan.uploadInBackground";
+    private static final String MAVEN_EXT_CLASS_PATH_PROPERTY_KEY = "maven.ext.class.path";
+    private static final String GE_ALLOW_UNTRUSTED_VAR = "JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER";
+    private static final String GE_URL_VAR = "JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL";
+    public static final String LIB_DIR_PATH = "jenkins-gradle-plugin/lib";
+
+    @Override
+    public String getActivationEnvironmentVariableName() {
+        return "JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_EXTENSION_VERSION";
+    }
+
+    @Override
+    public void inject(Node node, EnvVars envGlobal, EnvVars envComputer) {
+        if (node == null) {
+            return;
+        }
+
+        FilePath rootPath = node.getRootPath();
+        if (rootPath == null) {
+            return;
+        }
+
+        if (isEnabled(envGlobal)) {
+            injectMavenExtension(rootPath);
+        } else {
+            removeMavenExtension(rootPath);
+        }
+    }
+
+    private void injectMavenExtension(FilePath rootPath) {
+        try {
+            String cp = constructExtClasspath(copyResourceToAgent(GE_MVN_LIB_NAME, rootPath), copyResourceToAgent(CCUD_LIB_NAME, rootPath));
+            List<String> mavenOptsKeyValuePairs = new ArrayList<>();
+            mavenOptsKeyValuePairs.add(asSystemProperty(MAVEN_EXT_CLASS_PATH_PROPERTY_KEY, cp));
+            mavenOptsKeyValuePairs.add(asSystemProperty(GRADLE_SCAN_UPLOAD_IN_BACKGROUND_PROPERTY_KEY, "false"));
+
+            if (getGlobalEnvVar(GE_ALLOW_UNTRUSTED_VAR) != null) {
+                mavenOptsKeyValuePairs.add(asSystemProperty(GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY, getGlobalEnvVar(GE_ALLOW_UNTRUSTED_VAR)));
+            }
+            if (getGlobalEnvVar(GE_URL_VAR) != null) {
+                mavenOptsKeyValuePairs.add(asSystemProperty(GRADLE_ENTERPRISE_URL_PROPERTY_KEY, getGlobalEnvVar(GE_URL_VAR)));
+            }
+            rootPath.act(new SetMavenOpts(mavenOptsKeyValuePairs));
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void removeMavenExtension(FilePath rootPath) {
+        try {
+            deleteResourceFromAgent(GE_MVN_LIB_NAME, rootPath);
+            deleteResourceFromAgent(CCUD_LIB_NAME, rootPath);
+            rootPath.act(new ClearMavenOpts(
+                    MAVEN_EXT_CLASS_PATH_PROPERTY_KEY,
+                    GRADLE_SCAN_UPLOAD_IN_BACKGROUND_PROPERTY_KEY,
+                    GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY,
+                    GRADLE_ENTERPRISE_URL_PROPERTY_KEY
+            ));
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String constructExtClasspath(FilePath... libs) {
+        return Stream.of(libs).map(FilePath::getRemote).collect(Collectors.joining(":"));
+    }
+
+    private String getGlobalEnvVar(String varName) {
+        EnvironmentVariablesNodeProperty envProperty = Jenkins.get().getGlobalNodeProperties()
+                .get(EnvironmentVariablesNodeProperty.class);
+        return envProperty.getEnvVars().get(varName);
+    }
+
+    private String asSystemProperty(String sysProp, String value) {
+        return "-D" + sysProp + "=" + value;
+    }
+
+    private FilePath copyResourceToAgent(String resourceName, FilePath rootPath) throws IOException, InterruptedException {
+        FilePath lib = rootPath.child(LIB_DIR_PATH).child(resourceName);
+        InputStream libIs = getClass().getResourceAsStream(resourceName);
+        if (libIs == null) {
+            throw new IllegalStateException("Could not find resource: " + resourceName);
+        }
+        lib.copyFrom(libIs);
+        return lib;
+    }
+
+    private void deleteResourceFromAgent(String resourceName, FilePath rootPath) throws IOException, InterruptedException {
+        FilePath lib = rootPath.child(LIB_DIR_PATH).child(resourceName);
+        lib.delete();
+    }
+
+}

--- a/src/main/java/hudson/plugins/gradle/injection/SetMavenOpts.java
+++ b/src/main/java/hudson/plugins/gradle/injection/SetMavenOpts.java
@@ -1,0 +1,30 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.EnvVars;
+import jenkins.security.MasterToSlaveCallable;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+public class SetMavenOpts extends MasterToSlaveCallable<Void, RuntimeException> {
+
+    private static final Logger LOGGER = Logger.getLogger(SetMavenOpts.class.getName());
+
+    private final String mavenOptsValue;
+    public SetMavenOpts(List<String> mavenOptsKeyValuePairs) {
+        this.mavenOptsValue = String.join(" ", mavenOptsKeyValuePairs);
+    }
+
+    @Override
+    public Void call() {
+        String newMavenOpts;
+        String oldMavenOpts = EnvVars.masterEnvVars.get("MAVEN_OPTS");
+        if (oldMavenOpts != null) {
+            newMavenOpts = oldMavenOpts + " " + mavenOptsValue;
+        } else {
+            newMavenOpts = mavenOptsValue;
+        }
+        EnvVars.masterEnvVars.put("MAVEN_OPTS", newMavenOpts);
+        return null;
+    }
+}

--- a/src/main/resources/scripts/init-script.gradle
+++ b/src/main/resources/scripts/init-script.gradle
@@ -1,0 +1,175 @@
+import org.gradle.util.GradleVersion
+
+// note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
+
+// conditionally apply the GE / Build Scan plugin to the classpath so it can be applied to the build further down in this script
+initscript {
+  def isTopLevelBuild = !gradle.parent
+  if (!isTopLevelBuild) {
+    return
+  }
+
+  def getInputParam = { String name ->
+    def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+    return System.getProperty(name) ?: System.getenv(envVarName)
+  }
+  def gePluginVersion = getInputParam('jenkinsGradlePlugin.gradle-enterprise.plugin.version')
+  def ccudPluginVersion = getInputParam('jenkinsGradlePlugin.ccud.plugin.version')
+
+  def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
+  def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+
+  if (gePluginVersion || ccudPluginVersion && atLeastGradle4) {
+    repositories {
+      maven { url 'https://plugins.gradle.org/m2' }
+    }
+  }
+
+  dependencies {
+    if (gePluginVersion) {
+      classpath atLeastGradle5 ?
+              "com.gradle:gradle-enterprise-gradle-plugin:$gePluginVersion" :
+              "com.gradle:build-scan-plugin:1.16"
+    }
+
+    if (ccudPluginVersion && atLeastGradle4) {
+      classpath "com.gradle:common-custom-user-data-gradle-plugin:$ccudPluginVersion"
+    }
+  }
+}
+
+def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
+def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
+
+def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
+def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+
+def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
+def CCUD_PLUGIN_CLASS = 'com.gradle.CommonCustomUserDataGradlePlugin'
+
+def isTopLevelBuild = !gradle.parent
+if (!isTopLevelBuild) {
+  return
+}
+
+def getInputParam = { String name ->
+  def envVarName = name.toUpperCase().replace('.', '_').replace('-', '_')
+  return System.getProperty(name) ?: System.getenv(envVarName)
+}
+def geUrl = getInputParam('jenkinsGradlePlugin.gradle-enterprise.url')
+def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('jenkinsGradlePlugin.gradle-enterprise.allow-untrusted-server'))
+def gePluginVersion = getInputParam('jenkinsGradlePlugin.gradle-enterprise.plugin.version')
+def ccudPluginVersion = getInputParam('jenkinsGradlePlugin.ccud.plugin.version')
+
+def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+
+// finish early if configuration parameters passed in via system properties are not valid/supported
+if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
+  logger.warn("Common Custom User Data Gradle plugin must be at least 1.7. Configured version is $ccudPluginVersion.")
+  return
+}
+
+// send a message to the server that the build has started
+logger.quiet(generateBuildScanLifeCycleMessage('BUILD_STARTED'))
+
+// define a buildScanPublished listener that captures the build scan URL and sends it in a message to the server
+def buildScanPublishedAction = { def buildScan ->
+  if (buildScan.metaClass.respondsTo(buildScan, 'buildScanPublished', Action)) {
+    buildScan.buildScanPublished { scan ->
+      logger.quiet(generateBuildScanLifeCycleMessage("BUILD_SCAN_URL:${scan.buildScanUri.toString()}"))
+    }
+  }
+}
+
+// register buildScanPublished listener and optionally apply the GE / Build Scan plugin
+if (GradleVersion.current() < GradleVersion.version('6.0')) {
+  rootProject {
+    buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
+      def resolutionResult = incoming.resolutionResult
+
+      if (gePluginVersion) {
+        def scanPluginComponent = resolutionResult.allComponents.find {
+          it.moduleVersion.with { group == "com.gradle" && (name == "build-scan-plugin" || name == "gradle-enterprise-gradle-plugin") }
+        }
+        if (!scanPluginComponent) {
+          logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
+          logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+          pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+          buildScan.server = geUrl
+          buildScan.allowUntrustedServer = geAllowUntrustedServer
+          buildScan.publishAlways()
+        }
+      }
+
+      if (ccudPluginVersion && atLeastGradle4) {
+        def ccudPluginComponent = resolutionResult.allComponents.find {
+          it.moduleVersion.with { group == "com.gradle" && name == "common-custom-user-data-gradle-plugin" }
+        }
+        if (!ccudPluginComponent) {
+          logger.quiet("Applying $CCUD_PLUGIN_CLASS via init script")
+          pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+        }
+      }
+    }
+
+    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+      buildScanPublishedAction(buildScan)
+    }
+  }
+} else {
+  gradle.settingsEvaluated { settings ->
+    if (gePluginVersion) {
+      if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
+        logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
+        logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+        settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+        extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
+          ext.server = geUrl
+          ext.allowUntrustedServer = geAllowUntrustedServer
+          ext.buildScan.publishAlways()
+        }
+      }
+    }
+
+    if (ccudPluginVersion) {
+      if (!settings.pluginManager.hasPlugin(CCUD_PLUGIN_ID)) {
+        logger.quiet("Applying $CCUD_PLUGIN_CLASS via init script")
+        settings.pluginManager.apply(initscript.classLoader.loadClass(CCUD_PLUGIN_CLASS))
+      }
+    }
+
+    extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
+      buildScanPublishedAction(ext.buildScan)
+    }
+  }
+}
+
+static def extensionsWithPublicType(def container, String publicType) {
+  container.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
+}
+
+static String generateBuildScanLifeCycleMessage(def attribute) {
+  return "##jenkins[hudson.plugins.gradle.injection.buildScanLifeCycle '${escape(attribute as String)}']" as String
+}
+
+static String escape(String value) {
+  return value?.toCharArray()?.collect { ch -> escapeChar(ch) }?.join()
+}
+
+static String escapeChar(char ch) {
+  String escapeCharacter = "|"
+  switch (ch) {
+    case '\n': return escapeCharacter + "n"
+    case '\r': return escapeCharacter + "r"
+    case '|': return escapeCharacter + "|"
+    case '\'': return escapeCharacter + "\'"
+    case '[': return escapeCharacter + "["
+    case ']': return escapeCharacter + "]"
+    default: return ch < 128 ? ch as String : escapeCharacter + String.format("0x%04x", (int) ch)
+  }
+}
+
+static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
+  GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
+}

--- a/src/test/groovy/hudson/plugins/gradle/JavaGitContainer.java
+++ b/src/test/groovy/hudson/plugins/gradle/JavaGitContainer.java
@@ -1,0 +1,15 @@
+package hudson.plugins.gradle;
+
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
+
+/**
+ * Fixture capable of running java programs and git over ssh.
+ *
+ * Copied from pipeline-maven-plugin.
+ * 
+ * @author Cyrille Le Clerc
+ */
+@DockerFixture(id="javagit", ports={22,8080})
+public class JavaGitContainer extends JavaContainer {
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -1,0 +1,247 @@
+package hudson.plugins.gradle.injection
+
+import hudson.EnvVars
+import hudson.model.FreeStyleProject
+import hudson.model.Label
+import hudson.plugins.gradle.AbstractIntegrationTest
+import hudson.plugins.gradle.Gradle
+import hudson.slaves.DumbSlave
+import hudson.slaves.EnvironmentVariablesNodeProperty
+import hudson.slaves.NodeProperty
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jvnet.hudson.test.CreateFileBuilder
+import org.jvnet.hudson.test.JenkinsRule
+import spock.lang.Unroll
+
+@Unroll
+class BuildScanInjectionGradleIntegrationTest extends AbstractIntegrationTest {
+
+  private static final String MSG_PUBLISH_BUILD_SCAN = "Publishing build scan..."
+
+  def 'build scan is published without GE plugin with Gradle manual step #gradleVersion'() {
+    given:
+    gradleInstallationRule.gradleVersion = gradleVersion
+    gradleInstallationRule.addInstallation()
+
+    DumbSlave slave = setupBuildInjection(false)
+    FreeStyleProject p = j.createFreeStyleProject()
+    p.setAssignedNode(slave)
+
+    p.buildersList.add(buildScriptBuilder())
+    p.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+
+    when:
+    def build = j.buildAndAssertSuccess(p)
+
+    then:
+    println JenkinsRule.getLog(build)
+    j.assertLogContains(MSG_PUBLISH_BUILD_SCAN, build)
+
+    where:
+    gradleVersion << ['4.10.3', '5.6.4', '6.9.2', '7.4.2']
+  }
+
+  def 'build scan is not published without JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION on manual step'() {
+    given:
+    gradleInstallationRule.gradleVersion = gradleVersion
+    gradleInstallationRule.addInstallation()
+    DumbSlave slave = j.createOnlineSlave()
+    FreeStyleProject p = j.createFreeStyleProject()
+    p.setAssignedNode(slave)
+
+    p.buildersList.add(buildScriptBuilder())
+    p.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+
+    when:
+    def build = j.buildAndAssertSuccess(p)
+
+    then:
+    println JenkinsRule.getLog(build)
+    j.assertLogNotContains(MSG_PUBLISH_BUILD_SCAN, build)
+
+    where:
+    gradleVersion << ['7.4.2']
+  }
+
+  def 'build scan is published without GE plugin with Gradle pipeline #gradleVersion'() {
+    given:
+    gradleInstallationRule.gradleVersion = gradleVersion
+    gradleInstallationRule.addInstallation()
+
+    setupBuildInjection(false)
+    def pipelineJob = j.createProject(WorkflowJob)
+
+    pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node {
+        withGradle {
+          def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+          writeFile file: 'settings.gradle', text: ''
+          writeFile file: 'build.gradle', text: ""
+          if (isUnix()) {
+            sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
+          } else {
+            bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
+          }
+        }
+      }
+    }
+""", false))
+
+    when:
+    def build = j.buildAndAssertSuccess(pipelineJob)
+
+    then:
+    j.waitForCompletion(build)
+    println JenkinsRule.getLog(build)
+    j.assertLogContains(MSG_PUBLISH_BUILD_SCAN, build)
+
+    where:
+    gradleVersion << ['4.10.3', '5.6.4', '6.9.2', '7.4.2']
+  }
+
+  def 'build scan is not published without JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION on pipeline'() {
+    given:
+    gradleInstallationRule.gradleVersion = gradleVersion
+    gradleInstallationRule.addInstallation()
+    def pipelineJob = j.createProject(WorkflowJob)
+
+    pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node {
+        withGradle {
+          def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+          writeFile file: 'settings.gradle', text: ''
+          writeFile file: 'build.gradle', text: ""
+          if (isUnix()) {
+            sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
+          } else {
+            bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
+          }
+        }
+      }
+    }
+""", false))
+
+    when:
+    def build = j.buildAndAssertSuccess(pipelineJob)
+
+    then:
+    println JenkinsRule.getLog(build)
+    j.assertLogNotContains(MSG_PUBLISH_BUILD_SCAN, build)
+
+    where:
+    gradleVersion << ['7.4.2']
+  }
+
+  def 'init script is copied in a custom gradle home'() {
+    given:
+    gradleInstallationRule.gradleVersion = gradleVersion
+    gradleInstallationRule.addInstallation()
+
+    setupBuildInjection(true)
+    def pipelineJob = j.createProject(WorkflowJob)
+
+    pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node {
+        withEnv(['JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION=3.10.1','JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION=1.7','JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL=http://foo.com','JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME=/tmp']){
+          withGradle {
+            def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+            writeFile file: 'settings.gradle', text: ''
+            writeFile file: 'build.gradle', text: ""
+            if (isUnix()) {
+              sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
+            } else {
+              bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
+            }
+          }
+
+          def exists = fileExists '/tmp/.gradle/init.d/init-build-scan.gradle'
+          if (!exists) {
+            error "Gradle init script not found"
+          }
+        }
+      }
+    }
+""", false))
+
+    when:
+    def build = j.buildAndAssertSuccess(pipelineJob)
+
+    then:
+    println JenkinsRule.getLog(build)
+
+    where:
+    gradleVersion << ['7.4.2']
+  }
+
+  def 'init script is deleted without JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION'() {
+    given:
+    gradleInstallationRule.gradleVersion = gradleVersion
+    gradleInstallationRule.addInstallation()
+
+    NodeProperty nodeProperty = new EnvironmentVariablesNodeProperty()
+    EnvVars env = nodeProperty.getEnvVars()
+    env.put('JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME','/tmp')
+    j.jenkins.globalNodeProperties.add(nodeProperty)
+    j.createOnlineSlave(Label.get("foo"), env)
+    def pipelineJob = j.createProject(WorkflowJob)
+
+    pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node {
+        withGradle {
+          def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+          writeFile file: 'settings.gradle', text: ''
+          writeFile file: 'build.gradle', text: ""
+          if (isUnix()) {
+            sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
+          } else {
+            bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
+          }
+        }
+
+        def exists = fileExists '/tmp/.gradle/init.d/init-build-scan.gradle'
+        if (exists) {
+          error "Gradle init script not deleted"
+        }
+      }
+    }
+""", false))
+
+    when:
+    def build = j.buildAndAssertSuccess(pipelineJob)
+
+    then:
+    println JenkinsRule.getLog(build)
+
+    where:
+    gradleVersion << ['7.4.2']
+  }
+
+  private static CreateFileBuilder buildScriptBuilder() {
+    return new CreateFileBuilder('build.gradle', """
+task hello { doLast { println 'Hello' } }""")
+  }
+
+  private static boolean isUnix() {
+    return File.pathSeparatorChar == ':' as char
+  }
+
+  private DumbSlave setupBuildInjection(boolean withCustomGradleHome) {
+    NodeProperty nodeProperty = new EnvironmentVariablesNodeProperty()
+    EnvVars env = nodeProperty.getEnvVars()
+    env.put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION', '3.10.1')
+    env.put('JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION', '1.7')
+    env.put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL', 'http://foo.com')
+    if(withCustomGradleHome){
+      env.put('JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME','/tmp')
+    }
+    j.jenkins.globalNodeProperties.add(nodeProperty)
+    DumbSlave slave = j.createOnlineSlave(Label.get("foo"), env)
+    slave
+  }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -1,0 +1,116 @@
+package hudson.plugins.gradle.injection
+
+import com.cloudbees.plugins.credentials.Credentials
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider
+import com.cloudbees.plugins.credentials.domains.Domain
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
+import hudson.EnvVars
+import hudson.plugins.gradle.AbstractIntegrationTest
+import hudson.plugins.gradle.JavaGitContainer
+import hudson.plugins.sshslaves.SSHLauncher
+import hudson.slaves.DumbSlave
+import hudson.slaves.EnvironmentVariablesNodeProperty
+import hudson.slaves.RetentionStrategy
+import hudson.tasks.Maven
+import jenkins.model.Jenkins
+import jenkins.mvn.DefaultGlobalSettingsProvider
+import jenkins.mvn.DefaultSettingsProvider
+import jenkins.mvn.GlobalMavenConfig
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.test.acceptance.docker.DockerRule
+import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer
+import org.junit.Rule
+import org.jvnet.hudson.test.JenkinsRule
+import org.jvnet.hudson.test.ToolInstallations
+
+class BuildScanInjectionMavenIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String SSH_CREDENTIALS_ID = "test";
+    private static final String AGENT_NAME = "remote";
+    private static final String SLAVE_BASE_PATH = "/home/test/slave";
+
+    @Rule
+    public DockerRule<JavaGitContainer> javaGitContainerRule = new DockerRule<>(JavaGitContainer.class);
+
+    def 'build scan is published without GE plugin with pipeline withMaven'() {
+        given:
+        registerAgentForContainer(javaGitContainerRule.get())
+
+        and:
+        def pipelineJob = j.createProject(WorkflowJob)
+
+        def mavenInstallation = ToolInstallations.configureMaven35()
+        Jenkins.get().getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(mavenInstallation)
+        def mavenInstallationName = mavenInstallation.getName()
+
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty()
+        EnvVars env = prop.getEnvVars()
+        env.put("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_EXTENSION_VERSION", "1.14.2")
+        j.jenkins.getGlobalNodeProperties().add(prop)
+
+        GlobalMavenConfig globalMavenConfig = j.get(GlobalMavenConfig.class);
+        globalMavenConfig.setGlobalSettingsProvider(new DefaultGlobalSettingsProvider())
+        globalMavenConfig.setSettingsProvider(new DefaultSettingsProvider())
+
+
+        def pomFile = '''<?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>my-pom</artifactId>
+                    <version>0.1-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <name>my-pom</name>
+                    <description>my-pom</description>
+                </project>'''
+
+        pipelineJob.setDefinition(new CpsFlowDefinition("""
+node {
+   stage('Build') {
+        node('$AGENT_NAME') {
+            withMaven(maven: '$mavenInstallationName') {
+                sh "env"
+                sh '''cat <<EOT >> pom.xml
+$pomFile
+EOT'''
+                sh "mvn package"
+            }
+        }
+   }
+}
+""", false))
+
+        when:
+        def build = j.buildAndAssertSuccess(pipelineJob)
+
+        then:
+        println JenkinsRule.getLog(build)
+        j.assertLogContains('Publishing a build scan to scans.gradle.com ', build)
+    }
+
+    private void registerAgentForContainer(SshdContainer container) throws Exception {
+        addTestSshCredentials();
+        registerAgentForSlaveContainer(container);
+    }
+
+    private void registerAgentForSlaveContainer(SshdContainer slaveContainer) throws Exception {
+        SSHLauncher sshLauncher = new SSHLauncher(slaveContainer.ipBound(22), slaveContainer.port(22), SSH_CREDENTIALS_ID);
+
+        DumbSlave agent = new DumbSlave(AGENT_NAME, SLAVE_BASE_PATH, sshLauncher);
+        agent.setNumExecutors(1);
+        agent.setRetentionStrategy(RetentionStrategy.INSTANCE);
+
+        j.jenkins.addNode(agent);
+    }
+
+    private void addTestSshCredentials() {
+        Credentials credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, SSH_CREDENTIALS_ID, null, "test", "test");
+
+        SystemCredentialsProvider.getInstance()
+            .getDomainCredentialsMap()
+            .put(Domain.global(), Collections.singletonList(credentials));
+    }
+}

--- a/src/test/resources/hudson/plugins/gradle/JavaGitContainer/Dockerfile
+++ b/src/test/resources/hudson/plugins/gradle/JavaGitContainer/Dockerfile
@@ -1,0 +1,9 @@
+#
+# Container for running Jenkins builds using Git
+#
+
+# cf. JavaContainer/Dockerfile
+FROM jenkins/java:d93654cc6239
+
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y git


### PR DESCRIPTION
Add the ability to enable Build Scans for both Gradle and Maven builds without having to change any pipeline. The feature is enabled by setting specific environment variables, see README.adoc for more information.
