### PR TITLE
Allow opt-out of build scan injection

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanInjectionListener.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanInjectionListener.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 public class BuildScanInjectionListener extends ComputerListener {
 
     private static final Logger LOGGER = Logger.getLogger(BuildScanInjectionListener.class.getName());
+    private static final boolean DISABLED = Boolean.getBoolean(BuildScanInjectionListener.class.getName() + ".disabled");
 
     private final List<BuildScanInjection> injections = Arrays.asList(
             new GradleBuildScanInjection(),
@@ -25,6 +26,9 @@ public class BuildScanInjectionListener extends ComputerListener {
 
     @Override
     public void onOnline(Computer c, TaskListener listener) {
+        if (DISABLED) {
+            return;
+        }
         try {
             EnvVars envGlobal = c.buildEnvironment(listener);
             EnvVars envComputer = c.getEnvironment();
@@ -38,6 +42,9 @@ public class BuildScanInjectionListener extends ComputerListener {
 
     @Override
     public void onConfigurationChange() {
+        if (DISABLED) {
+            return;
+        }
         EnvironmentVariablesNodeProperty envProperty = Jenkins.get().getGlobalNodeProperties()
                 .get(EnvironmentVariablesNodeProperty.class);
         EnvVars envGlobal = envProperty != null ? envProperty.getEnvVars() : null;


### PR DESCRIPTION
Hi,

Would you be open to opting out of build scan injection? I'm interested in this for two reasons:
1. We run a custom distribution that already has build scans configured.
2. We don't pass `$HOME` to our agents, so we started getting `Error: HOME is not set` on every agent connection.

To avoid the warning, I have started setting `JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_HOME=${mktemp -d)`, but I would prefer to set a property to opt-out.

The approach here would allow opting-out by setting a system property, similar to other features in Jenkins:

```
-Dhudson.plugins.gradle.injection.BuildScanInjectionListener.disabled=true
```

This isn't particularly testable, so I'm happy to use a different implementation if preferred. We could instead introduce a Guice module that injects a system property.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
