### PR TITLE
Require Java 11 to build the plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPluginWithGradle()
+buildPluginWithGradle(jdkVersions: ['11'])

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,8 @@ plugins {
 
 rootProject.name = 'gradle-plugin'
 
-if (!JavaVersion.current().java8) {
-  throw new GradleException('Build requires Java 8')
+if (!JavaVersion.current().java11) {
+  throw new GradleException('Build requires Java 11')
 }
 
 gradle.ext.ciBuild = System.getenv()['JENKINS_URL'] ? true : false


### PR DESCRIPTION
This PR changes the Java version requirement for the project from 8 to 11. This change is required by the follow-up PRs.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
