### PR TITLE
Fix test environment setup and remove unnecessary JVM environment check.

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/GradleBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleBuildScanInjection.java
@@ -39,7 +39,7 @@ public class GradleBuildScanInjection implements BuildScanInjection {
 
             removeInitScript(node.getChannel(), initScriptDirectory);
             if (injectionEnabledForNode(node, envGlobal)) {
-                if (!isGradleEnterpriseUrlSet(envGlobal, envComputer)) {
+                if (!isGradleEnterpriseUrlSet(envGlobal)) {
                     throw new IllegalStateException(
                         String.format("Required environment variable '%s' is not set",
                             JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL));
@@ -117,10 +117,7 @@ public class GradleBuildScanInjection implements BuildScanInjection {
         return new FilePath(channel, initScriptDirectory + "/" + GRADLE_INIT_FILE);
     }
 
-    private static boolean isGradleEnterpriseUrlSet(EnvVars envGlobal, EnvVars envComputer) {
-        if (EnvUtil.isSet(envGlobal, JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL)) {
-            return true;
-        }
-        return EnvUtil.isSet(envComputer, JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL);
+    private static boolean isGradleEnterpriseUrlSet(EnvVars envGlobal) {
+        return EnvUtil.isSet(envGlobal, JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL);
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BaseInjectionIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BaseInjectionIntegrationTest.groovy
@@ -14,8 +14,8 @@ class BaseInjectionIntegrationTest extends AbstractIntegrationTest {
         j.waitOnline(slave)
     }
 
-    DumbSlave createSlave(String label, EnvVars env = null) {
-        return j.createOnlineSlave(Label.get(label), env)
+    DumbSlave createSlave(String label) {
+        return j.createOnlineSlave(Label.get(label))
     }
 
     void configureEnvironmentVariables(DumbSlave slave, @DelegatesTo(EnvVars) Closure closure = {}) {

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -274,15 +274,14 @@ task hello {
     }
 
     private DumbSlave createSlave(boolean setGeUrl = true) {
-        def nodeProperty = new EnvironmentVariablesNodeProperty()
-        def env = nodeProperty.getEnvVars()
-
-        env.put('JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION', '1.7')
-        if (setGeUrl) {
-            env.put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL', 'http://foo.com')
+        withGlobalEnvVars {
+            put('JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION', '1.7')
+            if (setGeUrl) {
+                put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL', 'http://foo.com')
+            }
         }
 
-        return createSlave('foo', env)
+        return createSlave('foo')
     }
 
     private static String getGradleHome(DumbSlave slave, String gradleVersion) {
@@ -290,21 +289,15 @@ task hello {
     }
 
     private void enableBuildInjection(DumbSlave slave, String gradleVersion, URI repositoryAddress = null) {
-        NodeProperty nodeProperty = new EnvironmentVariablesNodeProperty()
-        EnvVars env = nodeProperty.getEnvVars()
-
-        // we override the location of the init script to a workspace internal folder to allow parallel test runs
-        env.put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_INJECTION', 'on')
-        env.put("JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_GRADLE_HOME", getGradleHome(slave, gradleVersion))
-        env.put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION', '3.10.1')
-        env.put('GRADLE_OPTS', '-Dscan.uploadInBackground=false')
-        if (repositoryAddress != null) {
-            env.put('JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL', repositoryAddress.toASCIIString())
+        withAdditionalGlobalEnvVars {
+            put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_INJECTION', 'on')
+            put("JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_GRADLE_HOME", getGradleHome(slave, gradleVersion))
+            put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION', '3.10.1')
+            put('GRADLE_OPTS', '-Dscan.uploadInBackground=false')
+            if (repositoryAddress != null) {
+                put('JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL', repositoryAddress.toASCIIString())
+            }
         }
-        j.jenkins.globalNodeProperties.clear()
-        j.jenkins.globalNodeProperties.add(nodeProperty)
-
-        // sync changes
         restartSlave(slave)
     }
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/InjectionUtilsTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/InjectionUtilsTest.groovy
@@ -2,7 +2,9 @@ package hudson.plugins.gradle.injection
 
 import com.google.common.collect.Sets
 import spock.lang.Specification
+import spock.lang.Unroll
 
+@Unroll
 class InjectionUtilsTest extends Specification {
 
     def 'isInjectionEnabledForNode - #labels - #disabledNodes - #enabledNodes'(List<String> labels, String disabledNodes, String enabledNodes, boolean shouldInject) {


### PR DESCRIPTION
[createOnlineSlave](https://github.com/c00ler/gradle-plugin/blob/5aefdb8129c91d177623085b621ed37b3689ef17/src/test/groovy/hudson/plugins/gradle/injection/BaseInjectionIntegrationTest.groovy#L18) sets the environment for the java command used to run the slave jar in the process builder. This is not an expected use-case so we replaced it with setting global env vars and also removed an unnecessary check.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

