### PR TITLE
Inject resources only if they have changed

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanInjection.java
@@ -5,15 +5,10 @@ import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public interface BuildScanInjection {
-
-    default boolean injectionEnabled(EnvVars env) {
-        return EnvUtil.isSet(env, getActivationEnvironmentVariableName());
-    }
 
     String getActivationEnvironmentVariableName();
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -1,6 +1,7 @@
 package hudson.plugins.gradle.injection
 
 import hudson.EnvVars
+import hudson.Util
 import hudson.model.FreeStyleProject
 import hudson.plugins.gradle.Gradle
 import hudson.slaves.DumbSlave
@@ -263,6 +264,77 @@ class BuildScanInjectionGradleIntegrationTest extends BaseInjectionIntegrationTe
         gradleVersion << GRADLE_VERSIONS
     }
 
+    def "doesn't copy init script if already exists"() {
+        given:
+        def gradleVersion = '7.5.1'
+
+        gradleInstallationRule.gradleVersion = gradleVersion
+        gradleInstallationRule.addInstallation()
+
+        DumbSlave agent = createSlave()
+
+        def initScript = new File(getGradleHome(agent, gradleVersion) + "/init.d/init-build-scan.gradle")
+
+        when:
+        enableBuildInjection(agent, gradleVersion, URI.create("https://my-company.com/m2/"))
+
+        then:
+        initScript.exists()
+        def firstLastModified = initScript.lastModified()
+        firstLastModified > 0
+
+        when:
+        enableBuildInjection(agent, gradleVersion)
+
+        then:
+        initScript.exists()
+        def secondLastModified = initScript.lastModified()
+        firstLastModified == secondLastModified
+    }
+
+    def "copies init script if it was changed"() {
+        given:
+        def gradleVersion = '7.5.1'
+
+        gradleInstallationRule.gradleVersion = gradleVersion
+        gradleInstallationRule.addInstallation()
+
+        DumbSlave agent = createSlave()
+
+        def initScript = new File(getGradleHome(agent, gradleVersion) + "/init.d/init-build-scan.gradle")
+
+        when:
+        enableBuildInjection(agent, gradleVersion, URI.create("https://my-company.com/m2/"))
+
+        then:
+        initScript.exists()
+        def firstLastModified = initScript.lastModified()
+        firstLastModified > 0
+        def firstDigest = Util.getDigestOf(initScript)
+        firstDigest != null
+
+        when:
+        initScript << "\n// comment"
+
+        then:
+        def secondLastModified = initScript.lastModified()
+        secondLastModified != firstLastModified
+        def secondDigest = Util.getDigestOf(initScript)
+        secondDigest != firstDigest
+
+        when:
+        enableBuildInjection(agent, gradleVersion)
+
+        then:
+        initScript.exists()
+        def thirdLastModified = initScript.lastModified()
+        thirdLastModified != firstLastModified
+        thirdLastModified != secondLastModified
+        def thirdDigest = Util.getDigestOf(initScript)
+        thirdDigest != secondDigest
+        thirdDigest == firstDigest
+    }
+
     private static CreateFileBuilder buildScriptBuilder() {
         return new CreateFileBuilder('build.gradle', """
 task hello {
@@ -295,7 +367,7 @@ task hello {
             put('JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION', '3.10.1')
             put('GRADLE_OPTS', '-Dscan.uploadInBackground=false')
             if (repositoryAddress != null) {
-                put('JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL', repositoryAddress.toASCIIString())
+                put('JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL', repositoryAddress.toString())
             }
         }
         restartSlave(slave)

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -2,6 +2,7 @@ package hudson.plugins.gradle.injection
 
 import hudson.FilePath
 import hudson.slaves.DumbSlave
+import hudson.slaves.EnvironmentVariablesNodeProperty
 import hudson.tasks.Maven
 import jenkins.model.Jenkins
 import jenkins.mvn.DefaultGlobalSettingsProvider
@@ -14,7 +15,137 @@ import org.jvnet.hudson.test.ToolInstallations
 
 class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTest {
 
-    def pomFile = '<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>my-pom</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging><name>my-pom</name><description>my-pom</description></project>'
+    private static final String GE_EXTENSION_JAR = "gradle-enterprise-maven-extension.jar"
+    private static final String CCUD_EXTENSION_JAR = "common-custom-user-data-maven-extension.jar"
+
+    private static final String POM_XML = '<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>my-pom</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging><name>my-pom</name><description>my-pom</description></project>'
+
+    def "doesn't copy extensions if they were not changed"() {
+        when:
+        def slave = createSlaveAndTurnOnInjection()
+        turnOnBuildInjectionAndRestart(slave)
+        def extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
+
+        then:
+        extensionDirectory.list().size() == 2
+
+        def originalGeExtension = extensionDirectory.list().find { it.name == GE_EXTENSION_JAR }
+        originalGeExtension != null
+        def originalGeExtensionLastModified = originalGeExtension.lastModified()
+        originalGeExtensionLastModified > 0
+        def originalGeExtensionDigest = originalGeExtension.digest()
+        originalGeExtensionDigest != null
+
+        def originalCcudExtension = extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR }
+        originalCcudExtension != null
+        def originalCcudExtensionLastModified = originalCcudExtension.lastModified()
+        originalCcudExtensionLastModified > 0
+        def originalCcudExtensionDigest = originalCcudExtension?.digest()
+        originalCcudExtensionDigest != null
+
+        when:
+        restartSlave(slave)
+
+        extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
+
+        then:
+        def updatedGeExtension = extensionDirectory.list().find { it.name == GE_EXTENSION_JAR }
+        updatedGeExtension != null
+        updatedGeExtension.lastModified() == originalGeExtensionLastModified
+        updatedGeExtension.digest() == originalGeExtensionDigest
+
+        def updatedCcudExtension = extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR }
+        updatedCcudExtension != null
+        updatedCcudExtension.lastModified() == originalCcudExtensionLastModified
+        updatedCcudExtension.digest() == originalCcudExtensionDigest
+    }
+
+    def 'copies a new version of the same extension if it was changed'() {
+        when:
+        def slave = createSlaveAndTurnOnInjection()
+        turnOnBuildInjectionAndRestart(slave)
+        def extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
+
+        then:
+        extensionDirectory.list().size() == 2
+
+        def originalGeExtension = extensionDirectory.list().find { it.name == GE_EXTENSION_JAR }
+        originalGeExtension != null
+        def originalGeExtensionLastModified = originalGeExtension.lastModified()
+        originalGeExtensionLastModified > 0
+        def originalGeExtensionDigest = originalGeExtension.digest()
+        originalGeExtensionDigest != null
+
+        def originalCcudExtension = extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR }
+        originalCcudExtension != null
+        def originalCcudExtensionLastModified = originalCcudExtension.lastModified()
+        originalCcudExtensionLastModified > 0
+        def originalCcudExtensionDigest = originalCcudExtension?.digest()
+        originalCcudExtensionDigest != null
+
+        when:
+        def random = new Random()
+
+        def geExtensionRandomBytes = new byte[10]
+        random.nextBytes(geExtensionRandomBytes)
+
+        originalGeExtension.copyFrom(new ByteArrayInputStream(geExtensionRandomBytes))
+
+        def ccudExtensionRandomBytes = new byte[10]
+        random.nextBytes(ccudExtensionRandomBytes)
+
+        originalCcudExtension.copyFrom(new ByteArrayInputStream(ccudExtensionRandomBytes))
+
+        extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
+
+        then:
+        extensionDirectory.list().find { it.name == GE_EXTENSION_JAR }?.lastModified() != originalGeExtensionLastModified
+        extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR }?.lastModified() != originalCcudExtensionLastModified
+
+        when:
+        restartSlave(slave)
+
+        extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
+
+        then:
+        def updatedGeExtension = extensionDirectory.list().find { it.name == GE_EXTENSION_JAR }
+        updatedGeExtension != null
+        updatedGeExtension.lastModified() != originalGeExtensionLastModified
+        updatedGeExtension.digest() == originalGeExtensionDigest
+
+        def updatedCcudExtension = extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR }
+        updatedCcudExtension != null
+        updatedCcudExtension.lastModified() != originalCcudExtensionLastModified
+        updatedCcudExtension.digest() == originalCcudExtensionDigest
+    }
+
+    def 'does not create new EnvironmentVariablesNodeProperty when MAVEN_OPTS changes'() {
+        when:
+        def slave = createSlaveAndTurnOnInjection()
+
+        then:
+        slave.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class).size() == 1
+
+        hasJarInMavenExt(slave, GE_EXTENSION_JAR)
+        !hasJarInMavenExt(slave, CCUD_EXTENSION_JAR)
+
+        when:
+        turnOnBuildInjectionAndRestart(slave)
+
+        then:
+        slave.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class).size() == 1
+
+        hasJarInMavenExt(slave, GE_EXTENSION_JAR)
+        hasJarInMavenExt(slave, CCUD_EXTENSION_JAR)
+
+        when:
+        turnOffBuildInjectionAndRestart(slave)
+
+        then:
+        slave.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class).size() == 1
+
+        getMavenOptsFromNodeProperties(slave) == ""
+    }
 
     def 'build scan is published without GE plugin with simple pipeline'() {
         given:
@@ -27,22 +158,23 @@ class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTes
 
         then:
         def log = JenkinsRule.getLog(build)
-        hasJarInMavenExt(log, 'gradle-enterprise-maven-extension')
-        !hasJarInMavenExt(log, 'common-custom-user-data-maven-extension')
+        hasJarInMavenExt(log, GE_EXTENSION_JAR)
+        !hasJarInMavenExt(log, CCUD_EXTENSION_JAR)
         hasBuildScanPublicationAttempt(log)
     }
 
-    def 'Extension jars are copied and removed properly'() {
-        given:
-        DumbSlave slave = createSlaveAndTurnOnInjection()
-        FilePath extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
-        def geExtensionFileName = getExtensionVersion(MavenExtensionsHandler.MavenExtension.GRADLE_ENTERPRISE.name)
-        def ccudExtensionFileName = getExtensionVersion(MavenExtensionsHandler.MavenExtension.CCUD.name)
+    def 'extension jars are copied and removed properly and MAVEN_OPTS is set'() {
+        when:
+        def slave = createSlaveAndTurnOnInjection()
+        def extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
 
-        expect:
+        then:
         extensionDirectory.exists()
         extensionDirectory.list().size() == 1
-        extensionDirectory.list().get(0).getName() as String == "gradle-enterprise-maven-extension-${geExtensionFileName}.jar"
+        extensionDirectory.list().find { it.name == GE_EXTENSION_JAR } != null
+
+        hasJarInMavenExt(slave, GE_EXTENSION_JAR)
+        !hasJarInMavenExt(slave, CCUD_EXTENSION_JAR)
 
         when:
         turnOffBuildInjectionAndRestart(slave)
@@ -51,14 +183,19 @@ class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTes
         then:
         extensionDirectory.list().size() == 0
 
+        getMavenOptsFromNodeProperties(slave) == ""
+
         when:
         turnOnBuildInjectionAndRestart(slave)
         extensionDirectory = slave.toComputer().node.rootPath.child(MavenExtensionsHandler.LIB_DIR_PATH)
 
         then:
-        def expected = ["common-custom-user-data-maven-extension-${ccudExtensionFileName}.jar", "gradle-enterprise-maven-extension-${geExtensionFileName}.jar"] as List<String>
         extensionDirectory.list().size() == 2
-        extensionDirectory.list().collect { it.name }.toSorted() == expected
+        extensionDirectory.list().find { it.name == GE_EXTENSION_JAR } != null
+        extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR } != null
+
+        hasJarInMavenExt(slave, GE_EXTENSION_JAR)
+        hasJarInMavenExt(slave, CCUD_EXTENSION_JAR)
 
         when:
         turnOnBuildInjectionAndRestart(slave, false)
@@ -66,7 +203,10 @@ class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTes
 
         then:
         extensionDirectory.list().size() == 1
-        extensionDirectory.list().get(0).getName() as String == "gradle-enterprise-maven-extension-${geExtensionFileName}.jar"
+        extensionDirectory.list().find { it.name == GE_EXTENSION_JAR } != null
+
+        hasJarInMavenExt(slave, GE_EXTENSION_JAR)
+        !hasJarInMavenExt(slave, CCUD_EXTENSION_JAR)
 
         when:
         turnOnBuildInjectionAndRestart(slave)
@@ -74,7 +214,11 @@ class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTes
 
         then:
         extensionDirectory.list().size() == 2
-        extensionDirectory.list().collect { it.name }.toSorted() == expected
+        extensionDirectory.list().find { it.name == GE_EXTENSION_JAR } != null
+        extensionDirectory.list().find { it.name == CCUD_EXTENSION_JAR } != null
+
+        hasJarInMavenExt(slave, GE_EXTENSION_JAR)
+        hasJarInMavenExt(slave, CCUD_EXTENSION_JAR)
 
         when:
         turnOffBuildInjectionAndRestart(slave)
@@ -82,6 +226,8 @@ class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTes
 
         then:
         extensionDirectory.list().size() == 0
+
+        getMavenOptsFromNodeProperties(slave) == ""
     }
 
     def 'injection is enabled and disabled based on node labels'() {
@@ -136,7 +282,7 @@ node {
    stage('Build') {
         node('foo') {
             withMaven(maven: '$mavenInstallationName') {
-                writeFile file: 'pom.xml', text: '$pomFile'
+                writeFile file: 'pom.xml', text: '$POM_XML'
                 if (isUnix()) {
                     sh "env"
                     sh "mvn package -B"
@@ -155,8 +301,8 @@ node {
 
         then:
         def log = JenkinsRule.getLog(build)
-        hasJarInMavenExt(log, 'gradle-enterprise-maven-extension')
-        !hasJarInMavenExt(log, 'common-custom-user-data-maven-extension')
+        hasJarInMavenExt(log, GE_EXTENSION_JAR)
+        !hasJarInMavenExt(log, CCUD_EXTENSION_JAR)
         hasBuildScanPublicationAttempt(log)
     }
 
@@ -177,8 +323,8 @@ node {
 
         then:
         def log = JenkinsRule.getLog(build)
-        hasJarInMavenExt(log, 'gradle-enterprise-maven-extension')
-        hasJarInMavenExt(log, 'common-custom-user-data-maven-extension')
+        hasJarInMavenExt(log, GE_EXTENSION_JAR)
+        hasJarInMavenExt(log, CCUD_EXTENSION_JAR)
         hasBuildScanPublicationAttempt(log)
     }
 
@@ -196,16 +342,16 @@ node {
         then:
         def log = JenkinsRule.getLog(build)
         log =~ /MAVEN_OPTS=.*-Dfoo=bar.*/
-        !hasJarInMavenExt(log, 'gradle-enterprise-maven-extension')
+        !hasJarInMavenExt(log, GE_EXTENSION_JAR)
         !hasBuildScanPublicationAttempt(log)
     }
 
-    private String simplePipeline() {
+    private static String simplePipeline() {
         """
 node {
    stage('Build') {
         node('foo') {
-                writeFile file: 'pom.xml', text: '$pomFile'
+                writeFile file: 'pom.xml', text: '$POM_XML'
                 if (isUnix()) {
                     sh "env"
                     sh "mvn package -B"
@@ -240,12 +386,17 @@ node {
     }
 
     private static boolean hasJarInMavenExt(String log, String jar) {
-        String version = getExtensionVersion(jar)
-        (log =~ /MAVEN_OPTS=.*-Dmaven\.ext\.class\.path=.*${jar}-${version}\.jar/).find()
+        (log =~ /MAVEN_OPTS=.*-Dmaven\.ext\.class\.path=.*${jar}/).find()
     }
 
-    private static String getExtensionVersion(String jar) {
-        new File(getClass().getResource("/versions/${jar}-version.txt").toURI()).getText()
+    private static boolean hasJarInMavenExt(DumbSlave slave, String jar) {
+        def mavenOpts = getMavenOptsFromNodeProperties(slave)
+        return mavenOpts && mavenOpts ==~ /.*-Dmaven\.ext\.class\.path=.*${jar}.*/
+    }
+
+    private static String getMavenOptsFromNodeProperties(DumbSlave slave) {
+        def all = slave.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class)
+        return all?.last()?.getEnvVars()?.get("MAVEN_OPTS")
     }
 
     private static boolean hasBuildScanPublicationAttempt(String log) {

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
@@ -1,0 +1,68 @@
+package hudson.plugins.gradle.injection
+
+import hudson.FilePath
+import hudson.plugins.gradle.injection.MavenExtensionsHandler.MavenExtension
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class MavenExtensionsHandlerTest extends Specification {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder()
+
+    @Subject
+    MavenExtensionsHandler mavenExtensionsHandler = new MavenExtensionsHandler()
+
+    @Unroll
+    def "only copies extension if it doesn't exist"(MavenExtension mavenExtension) {
+        given:
+        def folder = tempFolder.newFolder()
+        def root = new FilePath(folder)
+
+        when:
+        def firstFilePath = mavenExtensionsHandler.copyExtensionToAgent(mavenExtension, root)
+
+        then:
+        firstFilePath.exists()
+        def firstLastModified = firstFilePath.lastModified()
+        firstLastModified > 0
+
+        when:
+        def secondFilePath = mavenExtensionsHandler.copyExtensionToAgent(mavenExtension, root)
+
+        then:
+        secondFilePath.exists()
+        secondFilePath.remote == firstFilePath.remote
+        def secondLastModified = firstFilePath.lastModified()
+        secondLastModified == firstLastModified
+
+        where:
+        mavenExtension << MavenExtension.values()
+    }
+
+    def "removes all files"() {
+        given:
+        def folder = tempFolder.newFolder()
+        def root = new FilePath(folder)
+
+        when:
+        def geExtensionFilePath = mavenExtensionsHandler.copyExtensionToAgent(MavenExtension.GRADLE_ENTERPRISE, root)
+        def ccudExtensionFilePath = mavenExtensionsHandler.copyExtensionToAgent(MavenExtension.CCUD, root)
+
+        then:
+        geExtensionFilePath.exists()
+        ccudExtensionFilePath.exists()
+
+        geExtensionFilePath.getParent().remote == ccudExtensionFilePath.getParent().remote
+
+        when:
+        mavenExtensionsHandler.deleteAllExtensionsFromAgent(root)
+
+        then:
+        !geExtensionFilePath.exists()
+        !ccudExtensionFilePath.exists()
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This pull requests improves the performance of build scans injection by checking if required artifacts are already present. The check is done by comparing the files checksums. Such checks ensure that after the release of a new version of the plugin, the artifacts, if they were changed, will be updated. 

When setting `MAVEN_OPTS` the plugin is not creating a new `EnvironmentVariablesNodeProperty` every time but reuses an already existing one. 


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
