### PR TITLE
Align static imports order between groovy and java sources

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -1,4 +1,5 @@
-<ruleset xmlns="http://codenarc.org/ruleset/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<ruleset xmlns="http://codenarc.org/ruleset/1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
          xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
     <ruleset-ref path='rulesets/basic.xml'/>
@@ -10,5 +11,9 @@
     <ruleset-ref path='rulesets/dry.xml'/>
     <ruleset-ref path='rulesets/exceptions.xml'/>
     <ruleset-ref path='rulesets/groovyism.xml'/>
-    <ruleset-ref path='rulesets/imports.xml'/>
+    <ruleset-ref path='rulesets/imports.xml'>
+        <rule-config name='MisorderedStaticImports'>
+            <property name='comesBefore' value='false'/>
+        </rule-config>
+    </ruleset-ref>
 </ruleset>

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -24,8 +24,6 @@
 
 package hudson.plugins.gradle
 
-import static org.jvnet.hudson.test.JenkinsRule.getLog
-
 import com.gargoylesoftware.htmlunit.html.HtmlButton
 import com.gargoylesoftware.htmlunit.html.HtmlForm
 import com.gargoylesoftware.htmlunit.html.HtmlPage
@@ -39,6 +37,8 @@ import hudson.util.VersionNumber
 import org.jvnet.hudson.test.CreateFileBuilder
 import org.jvnet.hudson.test.JenkinsRule.WebClient
 import spock.lang.Unroll
+
+import static org.jvnet.hudson.test.JenkinsRule.getLog
 
 /**
  * Tests for the Gradle build step.
@@ -251,7 +251,7 @@ class GradlePluginIntegrationTest extends GradleAbstractIntegrationTest {
         assert installers.get(GradleInstaller)
     }
 
-    private String getHelloTask() {
+    private static String getHelloTask() {
         '''
         task hello {
             doLast {

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -1,9 +1,5 @@
 package hudson.plugins.gradle.injection
 
-import static hudson.plugins.gradle.injection.MavenBuildScanInjection.JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_ALLOW_UNTRUSTED_SERVER
-import static hudson.plugins.gradle.injection.MavenBuildScanInjection.JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_EXT_CLASSPATH
-import static hudson.plugins.gradle.injection.MavenBuildScanInjection.JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_SERVER_URL
-
 import hudson.FilePath
 import hudson.model.Result
 import hudson.slaves.DumbSlave
@@ -21,6 +17,10 @@ import org.junit.rules.RuleChain
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.ToolInstallations
 import spock.lang.Unroll
+
+import static hudson.plugins.gradle.injection.MavenBuildScanInjection.JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_ALLOW_UNTRUSTED_SERVER
+import static hudson.plugins.gradle.injection.MavenBuildScanInjection.JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_EXT_CLASSPATH
+import static hudson.plugins.gradle.injection.MavenBuildScanInjection.JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_SERVER_URL
 
 class BuildScanInjectionMavenIntegrationTest extends BaseInjectionIntegrationTest {
 


### PR DESCRIPTION
This pull request configures the  `codenarc` rule to ensure that static imports in the Groovy sources come after the nonstatic imports. It makes it consistent with the Java sources.
