### PR TITLE
Revert jpi ext change

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -95,7 +95,7 @@ def allTestTasks =
 
                 environment([
                     JENKINS_WAR: jenkinsWarLocation,
-                    LOCAL_JARS : testDependenciesDir.get().file("gradle.jpi"),
+                    LOCAL_JARS : testDependenciesDir.get().file("gradle.hpi"),
                     BROWSER    : gradle.ciBuild ? 'firefox-container' : 'chrome'
                 ])
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ jenkinsPlugin {
 
   // Plugin ID, defaults to the project name without trailing '-plugin'
   shortName = 'gradle'
-  
   fileExtension = 'hpi'
 
   compatibleSinceVersion = '1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,6 @@ jenkinsPlugin {
   // Plugin ID, defaults to the project name without trailing '-plugin'
   shortName = 'gradle'
 
-  fileExtension = 'jpi'
-
   compatibleSinceVersion = '1.0'
 
   developers {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ jenkinsPlugin {
 
   // Plugin ID, defaults to the project name without trailing '-plugin'
   shortName = 'gradle'
+
   fileExtension = 'hpi'
 
   compatibleSinceVersion = '1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ jenkinsPlugin {
 
   // Plugin ID, defaults to the project name without trailing '-plugin'
   shortName = 'gradle'
+  
+  fileExtension = 'hpi'
 
   compatibleSinceVersion = '1.0'
 


### PR DESCRIPTION
Hi 

I'm not sure why this change was made other than it was in commit [`07a9c1d` (#185)](https://github.com/jenkinsci/gradle-plugin/pull/185/commits/07a9c1df5975955b5c39dc74adb190839d41b034)

This breaks:
* Installing the Gradle plugin via the Acceptance Test Harness, see https://github.com/jenkinsci/acceptance-test-harness/issues/985
* Adding this plugin as a dependency to another plugin and running it with `mvn hpi:run`

It would be appreciated if a quick release could be done so we can have the acceptance tests passing again, if it was just the gradle plugin failing we would skip the tests but it also prevents any plugins working that depend on the gradle plugin...