### PR TITLE
Fix typo in Enriched job summary table

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/AbstractBuildScanAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/gradle/AbstractBuildScanAction/summary.jelly
@@ -15,7 +15,7 @@
                 <tr>
                     <th class="large-column">Project</th>
                     <th class="large-column">Tasks</th>
-                    <th class="medium-column">Built Tool Version</th>
+                    <th class="medium-column">Build Tool Version</th>
                     <th class="default-column">Outcome</th>
                     <th class="medium-column">Build Scan</th>
                 </tr>


### PR DESCRIPTION
`Build Tool Version` instead of `Built Tool Version`