### PR TITLE
Automatically download chrome driver when running on CI

### DIFF
--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -4,10 +4,10 @@ import java.net.URL
 
 plugins {
     java
+    id("buildlogic.chromedriver")
     id("de.undercouch.download") version "5.3.1"
 }
 
-val ciTeamCityBuild: Boolean by (gradle as ExtensionAware).extra
 val ciJenkinsBuild: Boolean by (gradle as ExtensionAware).extra
 
 java {
@@ -86,8 +86,6 @@ jenkinsVersions
                 languageVersion.set(jenkinsVersion.javaVersion)
             })
 
-            jvmArgumentProviders.add(ChromeDriverProvider(ciTeamCityBuild))
-
             doFirst {
                 environment(
                     mapOf(
@@ -149,15 +147,4 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL, val javaVer
 
     val requiredJavaVersion: JavaVersion
         get() = JavaVersion.toVersion(javaVersion.toString())
-}
-
-class ChromeDriverProvider(private val teamCityBuild: Boolean) : CommandLineArgumentProvider {
-
-    override fun asArguments(): Iterable<String> =
-        // If executed on TeamCity, we need to set the Chromedriver path
-        if (teamCityBuild) {
-            listOf("-Dwebdriver.chrome.driver=${System.getenv("HOME")}/.gradle/webdriver/chromedriver/chromedriver")
-        } else {
-            emptyList()
-        }
 }

--- a/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
@@ -1,0 +1,77 @@
+import org.gradle.api.internal.artifacts.transform.UnzipTransform
+import org.gradle.internal.os.OperatingSystem
+
+// Latest version: https://chromedriver.storage.googleapis.com/LATEST_RELEASE
+val chromeDriverVersion = "110.0.5481.77"
+val ciTeamCityBuild: Boolean by (gradle as ExtensionAware).extra
+
+val os: OperatingSystem = OperatingSystem.current()
+val driverOsFilenamePart = when {
+    os.isWindows -> "win32"
+    os.isMacOsX && os.nativePrefix.contains("aarch64") -> "mac_arm64"
+    os.isMacOsX -> "mac64"
+    os.isLinux && os.nativePrefix.contains("64") -> "linux64"
+    else -> "linux32"
+}
+
+repositories {
+    exclusiveContent {
+        forRepository {
+            ivy {
+                url = uri("https://chromedriver.storage.googleapis.com/")
+                patternLayout {
+                    artifact("[revision]/[artifact]_[classifier].[ext]")
+                }
+                metadataSources {
+                    artifact()
+                }
+            }
+        }
+        filter {
+            includeModule("chromedriver", "chromedriver")
+        }
+    }
+}
+
+val chromedriver: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+}
+
+dependencies {
+    registerTransform(UnzipTransform::class) {
+        from.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE)
+        to.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
+    }
+    chromedriver("chromedriver:chromedriver:${chromeDriverVersion}:${driverOsFilenamePart}@zip")
+}
+
+val killRunningChromedriverInstances by tasks.registering(Exec::class) {
+    if (os.isWindows) {
+        didWork = false
+    } else {
+        val echoOption = if (os.isLinux) "e" else "l"
+        commandLine("bash", "-c", "pkill -9 -${echoOption} chrome")
+        isIgnoreExitValue = true
+    }
+}
+
+if (ciTeamCityBuild) {
+    tasks.withType(Test::class).configureEach {
+        inputs.files(chromedriver)
+        jvmArgumentProviders += ChromeDriverProvider(chromedriver)
+
+        finalizedBy(killRunningChromedriverInstances)
+    }
+}
+
+class ChromeDriverProvider(@Internal val chromedriverDirectory: FileCollection) : CommandLineArgumentProvider {
+
+    override fun asArguments(): Iterable<String> {
+        val chromedriver = chromedriverDirectory.asFileTree.files.first { it.name == "chromedriver" }
+        // UnzipTransform does not preserve file permissions, so we're restoring it here
+        chromedriver.setExecutable(true)
+        return listOf("-Dwebdriver.chrome.driver=$chromedriver")
+    }
+}

--- a/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
@@ -47,17 +47,14 @@ dependencies {
     chromedriver("chromedriver:chromedriver:${chromeDriverVersion}:${driverOsFilenamePart}@zip")
 }
 
-val killRunningChromedriverInstances by tasks.registering(Exec::class) {
-    if (os.isWindows) {
-        didWork = false
-    } else {
+// We do not run acceptance-tests on Windows
+if (ciTeamCityBuild && !os.isWindows) {
+    val killRunningChromedriverInstances by tasks.registering(Exec::class) {
         val echoOption = if (os.isLinux) "e" else "l"
         commandLine("bash", "-c", "pkill -9 -${echoOption} chrome")
         isIgnoreExitValue = true
     }
-}
 
-if (ciTeamCityBuild) {
     tasks.withType(Test::class).configureEach {
         inputs.files(chromedriver)
         jvmArgumentProviders += ChromeDriverProvider(chromedriver)


### PR DESCRIPTION
Automatically download chrome driver when running acceptance tests on CI.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
