### PR TITLE
Do not set empty MAVEN_OPTS environment variable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -169,8 +169,8 @@ tasks.test {
     maxParallelForks = findProperty("maxParallelForks") as Int? ?: 3
     retry {
         if (isCi) {
-            maxRetries.set(1)
-            maxFailures.set(10)
+            maxRetries.set(2)
+            maxFailures.set(5)
         }
     }
 }

--- a/src/main/java/hudson/plugins/gradle/injection/EnvUtil.java
+++ b/src/main/java/hudson/plugins/gradle/injection/EnvUtil.java
@@ -31,6 +31,19 @@ public final class EnvUtil {
     }
 
     @CheckForNull
+    public static String getEnv(Node node, String key) {
+        List<EnvironmentVariablesNodeProperty> all =
+            node.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class);
+
+        if (all.isEmpty()) {
+            return null;
+        }
+
+        EnvironmentVariablesNodeProperty last = Iterables.getLast(all);
+        return last.getEnvVars().get(key);
+    }
+
+    @CheckForNull
     public static String getEnv(EnvVars env, String key) {
         return env != null ? env.get(key) : null;
     }

--- a/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
@@ -30,10 +30,10 @@ public class MavenBuildScanInjection implements BuildScanInjection {
     public static final String JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_ALLOW_UNTRUSTED_SERVER = "JENKINSGRADLEPLUGIN_MAVEN_PLUGIN_CONFIG_ALLOW_UNTRUSTED_SERVER";
 
     // Maven system properties passed on the CLI to a Maven build
-    private static final String GRADLE_ENTERPRISE_URL_PROPERTY_KEY = "gradle.enterprise.url";
-    private static final String GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY = "gradle.enterprise.allowUntrustedServer";
-    private static final String BUILD_SCAN_UPLOAD_IN_BACKGROUND_PROPERTY_KEY = "gradle.scan.uploadInBackground";
-    private static final String MAVEN_EXT_CLASS_PATH_PROPERTY_KEY = "maven.ext.class.path";
+    private static final SystemProperty.Key GRADLE_ENTERPRISE_URL_PROPERTY_KEY = SystemProperty.Key.required("gradle.enterprise.url");
+    private static final SystemProperty.Key BUILD_SCAN_UPLOAD_IN_BACKGROUND_PROPERTY_KEY = SystemProperty.Key.required("gradle.scan.uploadInBackground");
+    private static final SystemProperty.Key MAVEN_EXT_CLASS_PATH_PROPERTY_KEY = SystemProperty.Key.required("maven.ext.class.path");
+    private static final SystemProperty.Key GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY = SystemProperty.Key.optional("gradle.enterprise.allowUntrustedServer");
 
     private static final MavenOptsSetter MAVEN_OPTS_SETTER = new MavenOptsSetter(
         MAVEN_EXT_CLASS_PATH_PROPERTY_KEY,
@@ -136,7 +136,7 @@ public class MavenBuildScanInjection implements BuildScanInjection {
                 systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY, "true"));
             }
 
-            MAVEN_OPTS_SETTER.appendIfMissing(node, systemProperties);
+            MAVEN_OPTS_SETTER.append(node, systemProperties);
 
             // Configuration needed to support https://plugins.jenkins.io/maven-plugin/
             extensions.add(extensionsHandler.copyExtensionToAgent(MavenExtension.CONFIGURATION, nodeRootPath));
@@ -156,7 +156,7 @@ public class MavenBuildScanInjection implements BuildScanInjection {
     private void cleanup(Node node, FilePath rootPath) {
         try {
             extensionsHandler.deleteAllExtensionsFromAgent(rootPath);
-            MAVEN_OPTS_SETTER.remove(node);
+            MAVEN_OPTS_SETTER.removeIfNeeded(node);
             EnvUtil.removeEnvVars(node, ALL_INJECTED_ENVIRONMENT_VARIABLES);
         } catch (IOException | InterruptedException e) {
             throw new IllegalStateException(e);

--- a/src/main/java/hudson/plugins/gradle/injection/MavenOptsSetter.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenOptsSetter.java
@@ -1,7 +1,6 @@
 package hudson.plugins.gradle.injection;
 
 import hudson.model.Node;
-import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -51,7 +50,7 @@ class MavenOptsSetter {
 
     void removeIfNeeded(Node node) throws IOException, InterruptedException {
         String currentMavenOpts = getCurrentMavenOpts(node);
-        if (StringUtils.isBlank(currentMavenOpts)) {
+        if (currentMavenOpts == null || currentMavenOpts.isEmpty()) {
             return;
         }
 

--- a/src/main/java/hudson/plugins/gradle/injection/MavenOptsSetter.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenOptsSetter.java
@@ -1,11 +1,12 @@
 package hudson.plugins.gradle.injection;
 
-import com.google.common.collect.ImmutableSet;
-import hudson.EnvVars;
 import hudson.model.Node;
+import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -17,54 +18,81 @@ class MavenOptsSetter {
     private static final String MAVEN_OPTS_VAR = "MAVEN_OPTS";
 
     private final Set<String> keys;
+    private final Set<String> requiredKeys;
 
-    public MavenOptsSetter(String... keys) {
-        this.keys = ImmutableSet.copyOf(keys);
+    public MavenOptsSetter(SystemProperty.Key... keys) {
+        this.keys =
+            Arrays.stream(keys)
+                .map(k -> k.name)
+                .collect(
+                    Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+        this.requiredKeys =
+            Arrays.stream(keys)
+                .filter(k -> k.required)
+                .map(k -> k.name)
+                .collect(
+                    Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
     }
 
-    void appendIfMissing(Node node, List<SystemProperty> systemProperties) throws IOException, InterruptedException {
-        String geMavenOpts =
+    void append(Node node, List<SystemProperty> systemProperties) throws IOException, InterruptedException {
+        String additionalProperties =
             systemProperties
                 .stream()
                 .map(SystemProperty::asString)
                 .collect(Collectors.joining(SPACE));
 
-        String mavenOpts = removeSystemProperties(getMavenOpts(node)) + SPACE + geMavenOpts;
+        String mavenOpts =
+            filtered(getCurrentMavenOpts(node))
+                .map(current -> String.join(SPACE, current, additionalProperties))
+                .orElse(additionalProperties);
+
         EnvUtil.setEnvVar(node, MAVEN_OPTS_VAR, mavenOpts);
     }
 
-    void remove(Node node) throws IOException, InterruptedException {
-        String mavenOpts = removeSystemProperties(getMavenOpts(node));
+    void removeIfNeeded(Node node) throws IOException, InterruptedException {
+        String currentMavenOpts = getCurrentMavenOpts(node);
+        if (StringUtils.isBlank(currentMavenOpts)) {
+            return;
+        }
+
+        boolean hasAllRequiredKeys = requiredKeys.stream().allMatch(currentMavenOpts::contains);
+        if (!hasAllRequiredKeys) {
+            return;
+        }
+
+        String mavenOpts = filtered(currentMavenOpts).orElse(null);
         EnvUtil.setEnvVar(node, MAVEN_OPTS_VAR, mavenOpts);
     }
 
-    private String getMavenOpts(Node node) throws IOException, InterruptedException {
-        EnvVars nodeEnvVars = EnvVars.getRemote(node.getChannel());
-        return nodeEnvVars.get(MAVEN_OPTS_VAR);
+    @Nullable
+    private static String getCurrentMavenOpts(Node node) {
+        return EnvUtil.getEnv(node, MAVEN_OPTS_VAR);
     }
 
-    private String removeSystemProperties(String mavenOpts) throws RuntimeException {
+    private Optional<String> filtered(@Nullable String mavenOpts) throws RuntimeException {
         return Optional.ofNullable(mavenOpts)
-            .map(this::filterMavenOpts)
-            .orElse("");
+            .map(this::filterMavenOpts);
     }
 
     /**
-     * Splits MAVEN_OPTS at each space and then removes all key value pairs that contain
-     * any of the keys we want to remove.
+     * Splits {@code MAVEN_OPTS} at each space and then removes all key value pairs containing any of the keys
+     * that were added by the auto-injection.
      */
+    @Nullable
     private String filterMavenOpts(String mavenOpts) {
-        return Arrays.stream(mavenOpts.split(SPACE))
-            .filter(this::shouldBeKept)
-            .collect(Collectors.joining(SPACE))
-            .trim();
+        String filtered =
+            Arrays.stream(mavenOpts.split(SPACE))
+                .filter(this::shouldBeKept)
+                .collect(Collectors.joining(SPACE));
+
+        if (filtered.isEmpty()) {
+            return null;
+        }
+
+        return filtered;
     }
 
-    /**
-     * Checks for a MAVEN_OPTS key value pair whether it contains none of the keys we're looking for.
-     * In other words if this segment none of the keys, this method returns true.
-     */
-    private boolean shouldBeKept(String seg) {
-        return keys.stream().noneMatch(seg::contains);
+    private boolean shouldBeKept(String systemProperty) {
+        return keys.stream().noneMatch(systemProperty::contains);
     }
 }

--- a/src/main/java/hudson/plugins/gradle/injection/SystemProperty.java
+++ b/src/main/java/hudson/plugins/gradle/injection/SystemProperty.java
@@ -2,15 +2,40 @@ package hudson.plugins.gradle.injection;
 
 public final class SystemProperty {
 
-    private final String key;
+    private final Key key;
     private final String value;
 
-    public SystemProperty(String key, String value) {
+    public SystemProperty(Key key, String value) {
         this.key = key;
         this.value = value;
     }
 
     public String asString() {
-        return String.format("-D%s=%s", key, value);
+        return String.format("-D%s=%s", key.name, value);
+    }
+
+    public static final class Key {
+
+        public final String name;
+        public final boolean required;
+
+        private Key(String name, boolean required) {
+            this.name = name;
+            this.required = required;
+        }
+
+        /**
+         * System property that is always added to the {@code MAVEN_OPTS}.
+         */
+        public static Key required(String key) {
+            return new Key(key, true);
+        }
+
+        /**
+         * System property that is added to the {@code MAVEN_OPTS} conditionally.
+         */
+        public static Key optional(String key) {
+            return new Key(key, false);
+        }
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
@@ -36,8 +36,8 @@ abstract class AbstractIntegrationTest extends Specification {
         j.waitOnline(slave)
     }
 
-    DumbSlave createSlave(String label) {
-        return j.createOnlineSlave(Label.get(label))
+    DumbSlave createSlave(String label, EnvVars env = null) {
+        return j.createOnlineSlave(Label.get(label), env)
     }
 
     EnvVars withGlobalEnvVars(@DelegatesTo(EnvVars) Closure closure) {

--- a/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
@@ -5,6 +5,7 @@ import hudson.model.Cause
 import hudson.model.FreeStyleBuild
 import hudson.model.FreeStyleProject
 import hudson.model.Label
+import hudson.model.Node
 import hudson.model.ParametersAction
 import hudson.model.ParametersDefinitionProperty
 import hudson.model.TextParameterDefinition
@@ -45,9 +46,21 @@ abstract class AbstractIntegrationTest extends Specification {
 
         closure.setDelegate(env)
         closure.run()
-
         j.jenkins.globalNodeProperties.clear()
         j.jenkins.globalNodeProperties.add(nodeProperty)
+
+        env
+    }
+
+    EnvVars withNodeEnvVars(Node node, @DelegatesTo(EnvVars) Closure closure) {
+        NodeProperty nodeProperty = new EnvironmentVariablesNodeProperty()
+        EnvVars env = nodeProperty.getEnvVars()
+
+        closure.setDelegate(env)
+        closure.run()
+        node.nodeProperties.clear()
+        node.nodeProperties.add(nodeProperty)
+
         env
     }
 
@@ -56,8 +69,8 @@ abstract class AbstractIntegrationTest extends Specification {
 
         closure.setDelegate(config)
         closure.run()
-
         config.save()
+
         config
     }
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -116,7 +116,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
         def agent = createSlave('test')
 
         then:
-        getMavenOptsFromNodeProperties(agent) == null
+        noMavenOpts(agent)
     }
 
     @Issue('https://issues.jenkins.io/browse/JENKINS-70692')

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -166,7 +166,6 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
             }
             !it.hasNext()
         }
-        getMavenOptsFromNodeProperties(agent).startsWith(mavenOpts)
 
         when:
         turnOffBuildInjectionAndRestart(agent)

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -33,7 +33,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
     private static final String POM_XML = '<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>my-pom</artifactId><version>0.1-SNAPSHOT</version><packaging>pom</packaging><name>my-pom</name><description>my-pom</description></project>'
 
     @Unroll
-    def "doesn't copy extensions if it was not changed"() {
+    def 'does not copy #extension if it was not changed'() {
         when:
         def slave = createSlaveAndTurnOnInjection()
         turnOnBuildInjectionAndRestart(slave)
@@ -67,7 +67,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
     }
 
     @Unroll
-    def 'copies a new version of the same extension if it was changed'() {
+    def 'copies a new version of #extension if it was changed'() {
         when:
         def slave = createSlaveAndTurnOnInjection()
         turnOnBuildInjectionAndRestart(slave)
@@ -122,7 +122,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
     @Issue('https://issues.jenkins.io/browse/JENKINS-70692')
     def 'does not modify existing MAVEN_OPTS if auto-injection is disabled'() {
         given:
-        def mavenOpts = 'foo=bar'
+        def mavenOpts = '-Dmaven.ext.class.path=/tmp/custom-extension.jar'
         def agent = createSlave('test')
 
         withNodeEnvVars(agent) {
@@ -131,6 +131,45 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
 
         when:
         restartSlave(agent)
+
+        then:
+        getMavenOptsFromNodeProperties(agent) == mavenOpts
+    }
+
+    def 'appends new properties to MAVEN_OPTS when auto-injection is enabled'() {
+        given:
+        def mavenOpts = '-Dfoo=bar'
+        def agent = createSlave('test')
+
+        withNodeEnvVars(agent) {
+            put('MAVEN_OPTS', mavenOpts)
+        }
+
+        when:
+        turnOnBuildInjectionAndRestart(agent)
+
+        then:
+        with(getMavenOptsFromNodeProperties(agent).split(" ").iterator()) {
+            with(it.next()) {
+                it == mavenOpts
+            }
+            with(it.next()) {
+                it.startsWith('-Dmaven.ext.class.path=')
+                it.contains('gradle-enterprise-maven-extension.jar')
+                it.contains('common-custom-user-data-maven-extension.jar')
+            }
+            with(it.next()) {
+                it == '-Dgradle.scan.uploadInBackground=false'
+            }
+            with(it.next()) {
+                it == '-Dgradle.enterprise.url=https://scans.gradle.com'
+            }
+            !it.hasNext()
+        }
+        getMavenOptsFromNodeProperties(agent).startsWith(mavenOpts)
+
+        when:
+        turnOffBuildInjectionAndRestart(agent)
 
         then:
         getMavenOptsFromNodeProperties(agent) == mavenOpts
@@ -161,7 +200,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
         then:
         slave.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class).size() == 1
 
-        getMavenOptsFromNodeProperties(slave) == ""
+        noMavenOpts(slave)
     }
 
     def 'build scan is published without GE plugin with simple pipeline'() {
@@ -204,7 +243,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
 
     def 'invalid access key is not injected into the simple pipeline'() {
         given:
-        def slave = createSlaveAndTurnOnInjection()
+        createSlaveAndTurnOnInjection()
         def mavenInstallationName = setupMavenInstallation()
 
         withInjectionConfig {
@@ -246,7 +285,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
         then:
         extensionDirectory.list().size() == 0
 
-        getMavenOptsFromNodeProperties(slave) == ""
+        noMavenOpts(slave)
 
         when:
         turnOnBuildInjectionAndRestart(slave)
@@ -296,7 +335,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
         then:
         extensionDirectory.list().size() == 0
 
-        getMavenOptsFromNodeProperties(slave) == ""
+        noMavenOpts(slave)
     }
 
     def 'injection is enabled and disabled based on node labels'() {
@@ -528,13 +567,17 @@ node {
         return mavenOpts && mavenOpts ==~ /.*-Dmaven\.ext\.class\.path=.*${jar}.*/
     }
 
+    private static boolean noMavenOpts(DumbSlave slave) {
+        getMavenOptsFromNodeProperties(slave) == null
+    }
+
     private static String getMavenOptsFromNodeProperties(DumbSlave slave) {
         return getEnvVarFromNodeProperties(slave, "MAVEN_OPTS")
     }
 
     private static String getEnvVarFromNodeProperties(DumbSlave slave, String envVar) {
         def all = slave.getNodeProperties().getAll(EnvironmentVariablesNodeProperty.class)
-        return all?.last()?.getEnvVars()?.get(envVar)
+        return all.empty ? null : all.last().getEnvVars().get(envVar)
     }
 
     private static boolean hasBuildScanPublicationAttempt(String log) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This pull request introduces the following changes:
* When maven auto-injection is disabled, update `MAVEN_OPTS` only if it has the changes added by auto-injection
* When maven auto-injection is disabled, remove `MAVEN_OPTS` instead of setting an empty value
* When maven auto-injection is enabled, merge changes with existing `MAVEN_OPTS` defined in the node properties. 

Fixes https://issues.jenkins.io/browse/JENKINS-70663 and https://issues.jenkins.io/browse/JENKINS-70692 