### PR TITLE
Configure depandabot to ignore maven-core versions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-    - dependency-name: org.jenkins-ci.main:jenkins-core
-      versions:
-      - ">= 0"
+      - dependency-name: "org.jenkins-ci.main:jenkins-core"
+      - dependency-name: "org.apache.maven:maven-core"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Do not update `maven-core`, as we want to have full control over the used version.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
