### PR TITLE
Set overflow to auto to display scrollbar only when necessary

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/AbstractBuildScanAction/enriched-css.jelly
+++ b/src/main/resources/hudson/plugins/gradle/AbstractBuildScanAction/enriched-css.jelly
@@ -9,13 +9,13 @@
             text-align:center;
             width:300px;
             max-width:300px;
-            overflow: scroll;
+            overflow: auto;
         }
         .medium-column {
             text-align:center;
             width:150px;
             max-width:150px;
-            overflow: scroll;
+            overflow: auto;
         }
     </style>
 </j:jelly>


### PR DESCRIPTION
fixes https://issues.jenkins.io/browse/JENKINS-70836

There is an option to always show scroll bars on MacOS:
<img width="708" alt="Screenshot 2023-03-22 at 3 36 39 PM" src="https://user-images.githubusercontent.com/10243934/226947137-14d580f0-74ca-47c1-b9ec-54a2ccc73910.png">

With this enabled, the summary page starts showing useless scrollbars:
<img width="1081" alt="Screenshot 2023-03-22 at 4 01 04 PM" src="https://user-images.githubusercontent.com/10243934/226946837-e7079635-c0e7-482c-941e-73db90f4447a.png">

To fix this, the `overflow` parameter should be set to `auto` as described in the [documentation](https://www.w3schools.com/css/css_overflow.asp#:~:text=By%20default%2C%20the%20overflow%20is,content%20overflows%20an%20element's%20box.):
<img width="1087" alt="Screenshot 2023-03-22 at 4 01 57 PM" src="https://user-images.githubusercontent.com/10243934/226946931-bb1f2652-e044-4cea-8ac3-0c312c69a968.png">
