### PR TITLE
Fix the exist check of jar paths for maven-plugin

### DIFF
--- a/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.internal.artifacts.transform.UnzipTransform
 import org.gradle.internal.os.OperatingSystem
 
 // Latest version: https://chromedriver.storage.googleapis.com/LATEST_RELEASE
-val chromeDriverVersion = "110.0.5481.77"
+val chromeDriverVersion = "111.0.5564.64"
 val ciTeamCityBuild: Boolean by (gradle as ExtensionAware).extra
 
 val os: OperatingSystem = OperatingSystem.current()

--- a/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.internal.artifacts.transform.UnzipTransform
 import org.gradle.internal.os.OperatingSystem
 
 // Latest version: https://chromedriver.storage.googleapis.com/LATEST_RELEASE
-val chromeDriverVersion = "111.0.5563.64"
+val chromeDriverVersion = "112.0.5615.49"
 val ciTeamCityBuild: Boolean by (gradle as ExtensionAware).extra
 
 val os: OperatingSystem = OperatingSystem.current()

--- a/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
+++ b/build-logic/src/main/kotlin/buildlogic.chromedriver.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.internal.artifacts.transform.UnzipTransform
 import org.gradle.internal.os.OperatingSystem
 
 // Latest version: https://chromedriver.storage.googleapis.com/LATEST_RELEASE
-val chromeDriverVersion = "111.0.5564.64"
+val chromeDriverVersion = "111.0.5563.64"
 val ciTeamCityBuild: Boolean by (gradle as ExtensionAware).extra
 
 val os: OperatingSystem = OperatingSystem.current()

--- a/src/main/java/hudson/plugins/gradle/injection/maven/GradleEnterpriseExtensionsContributorFactory.java
+++ b/src/main/java/hudson/plugins/gradle/injection/maven/GradleEnterpriseExtensionsContributorFactory.java
@@ -64,8 +64,7 @@ public class GradleEnterpriseExtensionsContributorFactory extends PlexusModuleCo
             List<FilePath> jars =
                 classpathFiles(node, classpath)
                     .stream()
-                    .map(File::new)
-                    .map(FilePath::new)
+                    .map(node::createPath)
                     .filter(this::filePathExists)
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
`GradleEnterpriseExtensionsContributorFactory` is invoked on the master node and by constructing the `FilePath` object as we do now, the `exists` check returns `false`, since those files actually are located on the agent `Node` (in case job is executed on an agent). This led to the fact that injection didn't work when maven-plugin is used and job was scheduled on a remote agent (works fine for built-in node and agents being on the same node as master)

This fix creates `FilePath` properly and the `exists` check now verifies its existence on the agent node instead of master one.
This has been tested manually using the docker setup. We would need to come up with a different test setup as well, since our current one uses either built-in node or agent being on the same filesystem.