### PR TITLE
Ensure Gradle Enterprise access key is not shown in a plain text

### DIFF
--- a/src/main/java/hudson/plugins/gradle/AbstractLogger.java
+++ b/src/main/java/hudson/plugins/gradle/AbstractLogger.java
@@ -1,0 +1,24 @@
+package hudson.plugins.gradle;
+
+import hudson.model.TaskListener;
+
+import java.io.Serializable;
+
+abstract class AbstractLogger implements Serializable {
+
+    private final String prefix;
+    private final TaskListener listener;
+
+    AbstractLogger(String prefix, TaskListener listener) {
+        this.prefix = prefix;
+        this.listener = listener;
+    }
+
+    public final void info(String message) {
+        listener.getLogger().printf("[%s] - %s%n", prefix, message);
+    }
+
+    public final void error(String message) {
+        listener.getLogger().printf("[%s] - [ERROR] - %s%n", prefix, message);
+    }
+}

--- a/src/main/java/hudson/plugins/gradle/GradleEnterpriseLogger.java
+++ b/src/main/java/hudson/plugins/gradle/GradleEnterpriseLogger.java
@@ -1,0 +1,10 @@
+package hudson.plugins.gradle;
+
+import hudson.model.TaskListener;
+
+public final class GradleEnterpriseLogger extends AbstractLogger {
+
+    public GradleEnterpriseLogger(TaskListener listener) {
+        super("Gradle Enterprise", listener);
+    }
+}

--- a/src/main/java/hudson/plugins/gradle/GradleLogger.java
+++ b/src/main/java/hudson/plugins/gradle/GradleLogger.java
@@ -2,24 +2,12 @@ package hudson.plugins.gradle;
 
 import hudson.model.TaskListener;
 
-import java.io.Serializable;
-
 /**
  * @author Gregory Boissinot
  */
-public class GradleLogger implements Serializable {
-
-    private final TaskListener listener;
+public final class GradleLogger extends AbstractLogger {
 
     public GradleLogger(TaskListener listener) {
-        this.listener = listener;
-    }
-
-    public void info(String message) {
-        listener.getLogger().println("[Gradle] - " + message);
-    }
-
-    public void error(String message) {
-        listener.getLogger().println("[Gradle] - [ERROR] " + message);
+        super("Gradle", listener);
     }
 }

--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -12,6 +12,7 @@ import hudson.plugins.gradle.GradleEnterpriseLogger;
 import hudson.util.Secret;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,14 +41,14 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
         return run.getAction(GradleEnterpriseParametersAction.class) != null;
     }
 
-    private static class GradleEnterpriseParametersAction extends ParametersAction {
+    public static class GradleEnterpriseParametersAction extends ParametersAction {
 
         private static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
 
         private static final GradleEnterpriseParametersAction EMPTY = new GradleEnterpriseParametersAction();
 
-        GradleEnterpriseParametersAction(List<ParameterValue> parameters) {
-            super(parameters);
+        GradleEnterpriseParametersAction(List<ParameterValue> parameters, Collection<String> additionalSafeParameters) {
+            super(parameters, additionalSafeParameters);
         }
 
         GradleEnterpriseParametersAction() {
@@ -60,9 +61,8 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
 
         static GradleEnterpriseParametersAction of(String accessKey) {
             return new GradleEnterpriseParametersAction(
-                Collections.singletonList(
-                    new PasswordParameterValue(GRADLE_ENTERPRISE_ACCESS_KEY, accessKey, null)
-                )
+                Collections.singletonList(new PasswordParameterValue(GRADLE_ENTERPRISE_ACCESS_KEY, accessKey, null)),
+                Collections.singleton(GRADLE_ENTERPRISE_ACCESS_KEY)
             );
         }
     }

--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -15,6 +15,7 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 @Extension
 public class BuildScanEnvironmentContributor extends EnvironmentContributor {
@@ -44,6 +45,7 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
     public static class GradleEnterpriseParametersAction extends ParametersAction {
 
         private static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
+        private static final Set<String> ADDITIONAL_SAFE_PARAMETERS = Collections.singleton(GRADLE_ENTERPRISE_ACCESS_KEY);
 
         private static final GradleEnterpriseParametersAction EMPTY = new GradleEnterpriseParametersAction();
 
@@ -62,7 +64,7 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
         static GradleEnterpriseParametersAction of(String accessKey) {
             return new GradleEnterpriseParametersAction(
                 Collections.singletonList(new PasswordParameterValue(GRADLE_ENTERPRISE_ACCESS_KEY, accessKey, null)),
-                Collections.singleton(GRADLE_ENTERPRISE_ACCESS_KEY)
+                ADDITIONAL_SAFE_PARAMETERS
             );
         }
     }

--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -3,46 +3,67 @@ package hudson.plugins.gradle.injection;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.EnvironmentContributor;
-import hudson.model.InvisibleAction;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.PasswordParameterValue;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.gradle.GradleEnterpriseLogger;
 import hudson.util.Secret;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
 
 @Extension
 public class BuildScanEnvironmentContributor extends EnvironmentContributor {
 
-    public static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
-
     @Override
     public void buildEnvironmentFor(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
         Secret secret = InjectionConfig.get().getAccessKey();
-        if (secret == null) {
+        if (secret == null || alreadyExecuted(run)) {
             return;
         }
 
         String accessKey = secret.getPlainText();
         if (!GradleEnterpriseAccessKeyValidator.getInstance().isValid(accessKey)) {
-            boolean shouldLog = run.getAction(InvalidGradleEnterpriseAccessKey.class) == null;
-            if (shouldLog) {
-                listener.error("Gradle Enterprise access key format is not valid");
-                run.addAction(InvalidGradleEnterpriseAccessKey.INSTANCE);
-            }
+            GradleEnterpriseLogger logger = new GradleEnterpriseLogger(listener);
+            logger.error("Gradle Enterprise access key format is not valid");
+            run.addAction(GradleEnterpriseParametersAction.empty());
             return;
         }
 
-        envs.put(GRADLE_ENTERPRISE_ACCESS_KEY, accessKey);
+        run.addAction(GradleEnterpriseParametersAction.of(accessKey));
     }
 
-    /**
-     * Marker action to ensure that we log error only once.
-     */
-    public static class InvalidGradleEnterpriseAccessKey extends InvisibleAction {
+    private static boolean alreadyExecuted(@Nonnull Run run) {
+        return run.getAction(GradleEnterpriseParametersAction.class) != null;
+    }
 
-        public static final InvalidGradleEnterpriseAccessKey INSTANCE = new InvalidGradleEnterpriseAccessKey();
+    private static class GradleEnterpriseParametersAction extends ParametersAction {
 
-        private InvalidGradleEnterpriseAccessKey() {
+        private static final String GRADLE_ENTERPRISE_ACCESS_KEY = "GRADLE_ENTERPRISE_ACCESS_KEY";
+
+        private static final GradleEnterpriseParametersAction EMPTY = new GradleEnterpriseParametersAction();
+
+        GradleEnterpriseParametersAction(List<ParameterValue> parameters) {
+            super(parameters);
+        }
+
+        GradleEnterpriseParametersAction() {
+            super(Collections.emptyList());
+        }
+
+        static GradleEnterpriseParametersAction empty() {
+            return EMPTY;
+        }
+
+        static GradleEnterpriseParametersAction of(String accessKey) {
+            return new GradleEnterpriseParametersAction(
+                Collections.singletonList(
+                    new PasswordParameterValue(GRADLE_ENTERPRISE_ACCESS_KEY, accessKey, null)
+                )
+            );
         }
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/AbstractIntegrationTest.groovy
@@ -28,6 +28,8 @@ import spock.lang.Specification
  */
 abstract class AbstractIntegrationTest extends Specification {
 
+    public static final String INVALID_ACCESS_KEY_FORMAT_ERROR = "[Gradle Enterprise] - [ERROR] - Gradle Enterprise access key format is not valid"
+
     public final JenkinsRule j = new JenkinsRule()
     public final TestRule noSpaceInTmpDirs = FlagRule.systemProperty("jenkins.test.noSpaceInTmpDirs", "true")
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
@@ -1,15 +1,17 @@
 package hudson.plugins.gradle.injection
 
 import hudson.EnvVars
+import hudson.model.PasswordParameterValue
 import hudson.model.Run
 import hudson.model.TaskListener
 import hudson.plugins.gradle.BaseJenkinsIntegrationTest
+import hudson.plugins.gradle.injection.BuildScanEnvironmentContributor.GradleEnterpriseParametersAction
 import hudson.util.Secret
 import spock.lang.Subject
 
 class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
 
-    def envs = new EnvVars()
+    def run = Mock(Run)
 
     @Subject
     def buildScanEnvironmentContributor = new BuildScanEnvironmentContributor()
@@ -21,26 +23,28 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         config.save()
 
         when:
-        buildScanEnvironmentContributor.buildEnvironmentFor(Mock(Run), envs, TaskListener.NULL)
+        buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        !envs.containsKey(BuildScanEnvironmentContributor.GRADLE_ENTERPRISE_ACCESS_KEY)
+        0 * run.addAction(_)
     }
 
-    def 'does nothing if access key is invalid'() {
+    def 'adds empty action if access key is invalid'() {
         given:
         def config = InjectionConfig.get()
         config.setAccessKey(Secret.fromString("secret"))
         config.save()
 
         when:
-        buildScanEnvironmentContributor.buildEnvironmentFor(Mock(Run), envs, TaskListener.NULL)
+        buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        !envs.containsKey(BuildScanEnvironmentContributor.GRADLE_ENTERPRISE_ACCESS_KEY)
+        1 * run.addAction { action ->
+            action.is(GradleEnterpriseParametersAction.empty())
+        }
     }
 
-    def 'adds access key to the environment'() {
+    def 'adds an action with the access key'() {
         given:
         def accessKey = "server=secret"
         def config = InjectionConfig.get()
@@ -48,9 +52,13 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         config.save()
 
         when:
-        buildScanEnvironmentContributor.buildEnvironmentFor(Mock(Run), envs, TaskListener.NULL)
+        buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        envs.get(BuildScanEnvironmentContributor.GRADLE_ENTERPRISE_ACCESS_KEY) == accessKey
+        1 * run.addAction { GradleEnterpriseParametersAction action ->
+            def parameters = action.getAllParameters()
+            parameters.size() == 1
+            parameters.first() == new PasswordParameterValue('GRADLE_ENTERPRISE_ACCESS_KEY', accessKey, null)
+        }
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -466,7 +466,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         j.assertLogContains(MSG_INIT_SCRIPT_APPLIED, secondRun)
         j.assertLogContains("accessKey=foo.com=secret", secondRun)
         j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.11.1/token was not from Gradle Enterprise.", secondRun)
-        j.assertLogNotContains("ERROR: Gradle Enterprise access key format is not valid", secondRun)
+        j.assertLogNotContains(INVALID_ACCESS_KEY_FORMAT_ERROR, secondRun)
 
     }
 
@@ -504,7 +504,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.11.1/token was not from Gradle Enterprise.", secondRun)
 
         and:
-        StringUtils.countMatches(JenkinsRule.getLog(secondRun), "ERROR: Gradle Enterprise access key format is not valid") == 1
+        StringUtils.countMatches(JenkinsRule.getLog(secondRun), INVALID_ACCESS_KEY_FORMAT_ERROR) == 1
     }
 
     def "sets all mandatory environment variables"() {

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -270,7 +270,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
 
         then:
         j.assertLogContains("GRADLE_ENTERPRISE_ACCESS_KEY=scans.gradle.com=secret", build)
-        j.assertLogNotContains("ERROR: Gradle Enterprise access key format is not valid", build)
+        j.assertLogNotContains(INVALID_ACCESS_KEY_FORMAT_ERROR, build)
         j.assertLogContains("[INFO] The Gradle Terms of Service have not been agreed to.", build)
     }
 
@@ -293,7 +293,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseJenkinsIntegrationTest 
         j.assertLogContains("[INFO] The Gradle Terms of Service have not been agreed to.", build)
 
         and:
-        StringUtils.countMatches(JenkinsRule.getLog(build), "ERROR: Gradle Enterprise access key format is not valid") == 1
+        StringUtils.countMatches(JenkinsRule.getLog(build), INVALID_ACCESS_KEY_FORMAT_ERROR) == 1
     }
 
     def 'extension jars are copied and removed properly and MAVEN_OPTS is set'() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Ensure Gradle Enterprise access key is not shown in plain text when [Environment Injector](https://plugins.jenkins.io/envinject/) plugin is used.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
