### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/GradleTaskNote/script.js
+++ b/src/main/resources/hudson/plugins/gradle/GradleTaskNote/script.js
@@ -10,17 +10,20 @@
 
         if (!loading) {
             loading = true;
-            var u = new Ajax.Updater(document.getElementById("side-panel"),
-                rootURL + "/descriptor/hudson.plugins.gradle.GradleTaskNote/outline",
-                {
-                    insertion: Insertion.Bottom, onComplete: function () {
-                    if (!u.success()) return; // we can't us onSuccess because that kicks in before onComplete
-                    outline = document.getElementById("gradle-console-outline-body")
-                        .getElementsByTagName('ul')[0];
-                    loading = false;
-                    queue.each(handle);
+            fetch(rootURL + "/descriptor/hudson.plugins.gradle.GradleTaskNote/outline", {
+                method: "post",
+                headers: crumb.wrap({}),
+            }).then(function(rsp) {
+                if (rsp.ok) {
+                    rsp.text().then((responseText) => {
+                        document.getElementById("side-panel").insertAdjacentHTML("beforeend", responseText);
+                        outline = document.getElementById("gradle-console-outline-body")
+                            .getElementsByTagName('ul')[0];
+                        loading = false;
+                        queue.forEach(handle);
+                    });
                 }
-                });
+            });
         }
         return true;
     }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. I tested a very similar change successfully in the context of https://github.com/jenkinsci/ant-plugin/pull/121.