### PR TITLE
Build on container agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPluginWithGradle(jdkVersions: ['11'], timeout: 180)
+buildPluginWithGradle(useContainerAgent: true, jdkVersions: ['11'], timeout: 180)


### PR DESCRIPTION
Container agents are usually faster to provision than a VM.