### PR TITLE
Fix credentials not masked when `DurableTaskStep.USE_WATCHING` is true

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionTaskListenerDecoratorFactory.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionTaskListenerDecoratorFactory.java
@@ -7,6 +7,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.log.TaskListenerDecorator;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -21,6 +22,7 @@ public class GradleEnterpriseExceptionTaskListenerDecoratorFactory implements Ta
     private static final Logger LOGGER = Logger.getLogger(GradleEnterpriseExceptionTaskListenerDecoratorFactory.class.getName());
 
     @Override
+    @CheckForNull
     public TaskListenerDecorator of(@Nonnull FlowExecutionOwner owner) {
         if (!isBuildAgentErrorsEnabled()) {
             return null;

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -16,7 +16,7 @@ import org.junit.rules.RuleChain
 abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
 
     public final GradleInstallationRule gradleInstallationRule = new GradleInstallationRule(j)
-    static final String GRADLE_ENTERPRISE_PLUGIN_VERSION = '3.13.2'
+    static final String GRADLE_ENTERPRISE_PLUGIN_VERSION = '3.13.4'
 
     @Rule
     public final RuleChain rules = RuleChain.outerRule(noSpaceInTmpDirs).around(j).around(gradleInstallationRule)

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -1,5 +1,12 @@
 package hudson.plugins.gradle
 
+import com.cloudbees.plugins.credentials.CredentialsProvider
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.domains.Domain
+import hudson.slaves.DumbSlave
+import hudson.util.Secret
+import org.jenkinsci.plugins.plaincredentials.StringCredentials
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
 import org.junit.Rule
 import org.junit.rules.RuleChain
 
@@ -9,6 +16,7 @@ import org.junit.rules.RuleChain
 abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
 
     public final GradleInstallationRule gradleInstallationRule = new GradleInstallationRule(j)
+    static final String GRADLE_ENTERPRISE_PLUGIN_VERSION = '3.13.2'
 
     @Rule
     public final RuleChain rules = RuleChain.outerRule(noSpaceInTmpDirs).around(j).around(gradleInstallationRule)
@@ -20,4 +28,35 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
             switches          : '--no-daemon'
         ]
     }
+
+    def enableBuildInjection(DumbSlave slave,
+                                      String gradleVersion,
+                                      URI repositoryAddress = null,
+                                      Boolean globalAutoInjectionCheckEnabled = false) {
+        withGlobalEnvVars {
+            put("JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_GRADLE_HOME", getGradleHome(slave, gradleVersion))
+            put('GRADLE_OPTS', '-Dscan.uploadInBackground=false')
+            if (globalAutoInjectionCheckEnabled) {
+                put("JENKINSGRADLEPLUGIN_GLOBAL_AUTO_INJECTION_CHECK", "true")
+            }
+        }
+
+        withInjectionConfig {
+            enabled = true
+            gradlePluginVersion = GRADLE_ENTERPRISE_PLUGIN_VERSION
+            gradlePluginRepositoryUrl = repositoryAddress?.toString()
+        }
+
+        restartSlave(slave)
+    }
+
+    static String getGradleHome(DumbSlave slave, String gradleVersion) {
+        return "${slave.getRemoteFS()}/tools/hudson.plugins.gradle.GradleInstallation/${gradleVersion}"
+    }
+
+    def registerCredentials(String id, String secret) {
+        StringCredentials creds = new StringCredentialsImpl(CredentialsScope.GLOBAL, id, null, Secret.fromString(secret))
+        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), creds)
+    }
+
 }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -610,7 +610,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         then:
         j.assertLogContains(MSG_INIT_SCRIPT_APPLIED, secondRun)
         j.assertLogContains("accessKey=foo.com=secret", secondRun)
-        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.13.2/token was not from Gradle Enterprise.", secondRun)
+        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.13.4/token was not from Gradle Enterprise.", secondRun)
         j.assertLogNotContains(INVALID_ACCESS_KEY_FORMAT_ERROR, secondRun)
 
     }
@@ -646,7 +646,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         then:
         j.assertLogContains(MSG_INIT_SCRIPT_APPLIED, secondRun)
-        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.13.2/token was not from Gradle Enterprise.", secondRun)
+        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.13.4/token was not from Gradle Enterprise.", secondRun)
 
         and:
         StringUtils.countMatches(JenkinsRule.getLog(secondRun), INVALID_ACCESS_KEY_FORMAT_ERROR) == 1
@@ -680,7 +680,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         with(agent.getNodeProperty(EnvironmentVariablesNodeProperty.class)) {
             with(getEnvVars()) {
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL") == "http://localhost"
-                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.13.2'
+                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.13.4'
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER") == null
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ENFORCE_URL") == null
                 get("JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL") == null
@@ -745,7 +745,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
             with(getEnvVars()) {
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL") == "http://localhost"
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ENFORCE_URL") == "true"
-                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.13.2'
+                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.13.4'
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER") == "true"
                 get("JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL") == "http://localhost/repository"
                 get("JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION") == "1.8.1"

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
@@ -1,0 +1,80 @@
+package hudson.plugins.gradle.injection
+
+import hudson.plugins.gradle.BaseGradleIntegrationTest
+import hudson.plugins.gradle.BuildScanAction
+import hudson.slaves.DumbSlave
+import org.junit.Rule
+import org.junit.rules.TestRule
+import org.jvnet.hudson.test.FlagRule
+import spock.lang.PendingFeature
+import spock.lang.Unroll
+
+@Unroll
+class BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest extends BaseGradleIntegrationTest {
+
+    private static final String MSG_INIT_SCRIPT_APPLIED = "Connection to Gradle Enterprise: http://foo.com"
+
+    @Rule
+    public final TestRule durableTaskStepRule = FlagRule.systemProperty("org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING", "true")
+
+    @PendingFeature
+    def "cannot capture build agent errors in pipeline build if DurableTaskStep.USE_WATCHING=true"() {
+        given:
+        def gradleVersion = '8.1.1'
+        gradleInstallationRule.gradleVersion = gradleVersion
+        gradleInstallationRule.addInstallation()
+
+        DumbSlave agent = createSlave('foo')
+        def pipelineJob = GradleSnippets.pipelineJobWithError(j, gradleInstallationRule)
+
+        when:
+        // first build to download Gradle
+        def firstRun = j.buildAndAssertSuccess(pipelineJob)
+
+        then:
+        j.assertLogNotContains(MSG_INIT_SCRIPT_APPLIED, firstRun)
+
+        when:
+        enableBuildInjection(agent, gradleVersion)
+        withInjectionConfig {
+            checkForBuildAgentErrors = true
+        }
+        def secondRun = buildAndAssertFailure(pipelineJob)
+
+        then:
+        secondRun.getAction(BuildScanAction) != null
+    }
+
+    def "credentials are always masked in logs"() {
+        given:
+        def secret = 'confidential'
+        registerCredentials('my-creds', secret)
+
+        def gradleVersion = '8.1.1'
+        gradleInstallationRule.gradleVersion = gradleVersion
+        gradleInstallationRule.addInstallation()
+
+        DumbSlave agent = createSlave('foo')
+        def pipelineJob = GradleSnippets.pipelineJobWithCredentials(j)
+
+        when:
+        // first build to download Gradle
+        def firstRun = j.buildAndAssertSuccess(pipelineJob)
+
+        then:
+        j.assertLogContains('password=****', firstRun)
+        j.assertLogNotContains(secret, firstRun)
+
+        when:
+        enableBuildInjection(agent, gradleVersion)
+        withInjectionConfig {
+            checkForBuildAgentErrors = true
+        }
+        def secondRun = j.buildAndAssertSuccess(pipelineJob)
+
+        then:
+        j.assertLogContains('password=****', secondRun)
+        j.assertLogNotContains(secret, secondRun)
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/GradleSnippets.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/GradleSnippets.groovy
@@ -1,0 +1,51 @@
+package hudson.plugins.gradle.injection
+
+import hudson.plugins.gradle.GradleInstallationRule
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jvnet.hudson.test.JenkinsRule
+
+class GradleSnippets {
+
+    def static pipelineJobWithError(JenkinsRule j, GradleInstallationRule gradleInstallationRule) {
+        def pipelineJob = j.createProject(WorkflowJob)
+
+        pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node('foo') {
+        withGradle {
+          def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+          writeFile file: 'settings.gradle', text: ''
+          writeFile file: 'build.gradle', text: ""
+          if (isUnix()) {
+            sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain -Dcom.gradle.scan.trigger-synthetic-error=true"
+          } else {
+            bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain -Dcom.gradle.scan.trigger-synthetic-error=true/)
+          }
+        }
+      }
+    }
+""", false))
+        return pipelineJob
+    }
+
+    def static pipelineJobWithCredentials(JenkinsRule j) {
+        def pipelineJob = j.createProject(WorkflowJob)
+
+        pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node('foo') {
+        withCredentials([string(credentialsId: 'my-creds', variable: 'PASSWORD')]) {
+          if (isUnix()) {
+            sh "echo password=\$PASSWORD"
+          } else {
+            bat "echo password=%PASSWORD%"
+          }
+        }
+      }
+    }
+""", false))
+        return pipelineJob
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/GradleSnippets.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/GradleSnippets.groovy
@@ -7,7 +7,7 @@ import org.jvnet.hudson.test.JenkinsRule
 
 class GradleSnippets {
 
-    def static pipelineJobWithError(JenkinsRule j, GradleInstallationRule gradleInstallationRule) {
+    static WorkflowJob pipelineJobWithError(JenkinsRule j, GradleInstallationRule gradleInstallationRule) {
         def pipelineJob = j.createProject(WorkflowJob)
 
         pipelineJob.setDefinition(new CpsFlowDefinition("""
@@ -29,7 +29,7 @@ class GradleSnippets {
         return pipelineJob
     }
 
-    def static pipelineJobWithCredentials(JenkinsRule j) {
+    static WorkflowJob pipelineJobWithCredentials(JenkinsRule j) {
         def pipelineJob = j.createProject(WorkflowJob)
 
         pipelineJob.setDefinition(new CpsFlowDefinition("""


### PR DESCRIPTION
This should fix https://issues.jenkins.io/browse/JENKINS-71509

Although this fixes the credentials masking when `org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING` is set to true, the original `GradleEnterpriseExceptionTaskListenerDecorator` does not work in this case. It does not "see" all the log lines, it will require more investigation.


<!-- Please describe your pull request here. -->

### Testing done
Provided integration tests
Manual tested on a local instance with the OpenTelemetry plugin (it sets `org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING` to true) that secrets are masked on:
- Simple pipeline build with credentials binding plugin
- Simple pipeline build with Hashicorp Vault plugin
- Simple freestyle build with Hashicorp Vault plugin

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
