### PR TITLE
[JENKINS-71509] Clean up of `GradleEnterpriseExceptionTaskListenerDecorator`

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionLogFilter.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionLogFilter.java
@@ -14,7 +14,7 @@ public class GradleEnterpriseExceptionLogFilter extends ConsoleLogFilter impleme
     @Override
     public OutputStream decorateLogger(Run build, OutputStream logger) {
         InjectionConfig injectionConfig = InjectionConfig.get();
-        if (injectionConfig.isEnabled() && injectionConfig.isCheckForBuildAgentErrors()) {
+        if (injectionConfig.isEnabled() && injectionConfig.isCheckForBuildAgentErrors() && build != null) {
             return new GradleEnterpriseExceptionLogProcessor(logger, build);
         }
         return logger;

--- a/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionLogProcessor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionLogProcessor.java
@@ -1,12 +1,16 @@
 package hudson.plugins.gradle.injection;
 
 import hudson.console.ConsoleNote;
+import hudson.model.Actionable;
 import hudson.model.Run;
 import hudson.plugins.gradle.AbstractGradleLogProcessor;
 import hudson.plugins.gradle.BuildAgentError;
 import hudson.plugins.gradle.BuildToolType;
 
+import javax.annotation.Nullable;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public final class GradleEnterpriseExceptionLogProcessor extends AbstractGradleLogProcessor {
 
@@ -24,9 +28,13 @@ public final class GradleEnterpriseExceptionLogProcessor extends AbstractGradleL
 
     private final BuildAgentErrorListener listener;
 
-    public GradleEnterpriseExceptionLogProcessor(OutputStream out, Run<?, ?> build) {
-        super(out, build.getCharset());
-        this.listener = new DefaultBuildAgentErrorListener(build);
+    public GradleEnterpriseExceptionLogProcessor(OutputStream out, @Nullable Run<?, ?> build) {
+        this(out, build != null ? build.getCharset() : StandardCharsets.UTF_8, build);
+    }
+
+    public GradleEnterpriseExceptionLogProcessor(OutputStream out, Charset charset, Actionable actionable) {
+        super(out, charset);
+        this.listener = new DefaultBuildAgentErrorListener(actionable);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionLogProcessor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionLogProcessor.java
@@ -1,16 +1,12 @@
 package hudson.plugins.gradle.injection;
 
 import hudson.console.ConsoleNote;
-import hudson.model.Actionable;
 import hudson.model.Run;
 import hudson.plugins.gradle.AbstractGradleLogProcessor;
 import hudson.plugins.gradle.BuildAgentError;
 import hudson.plugins.gradle.BuildToolType;
 
-import javax.annotation.Nullable;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 public final class GradleEnterpriseExceptionLogProcessor extends AbstractGradleLogProcessor {
 
@@ -28,13 +24,9 @@ public final class GradleEnterpriseExceptionLogProcessor extends AbstractGradleL
 
     private final BuildAgentErrorListener listener;
 
-    public GradleEnterpriseExceptionLogProcessor(OutputStream out, @Nullable Run<?, ?> build) {
-        this(out, build != null ? build.getCharset() : StandardCharsets.UTF_8, build);
-    }
-
-    public GradleEnterpriseExceptionLogProcessor(OutputStream out, Charset charset, Actionable actionable) {
-        super(out, charset);
-        this.listener = new DefaultBuildAgentErrorListener(actionable);
+    public GradleEnterpriseExceptionLogProcessor(OutputStream out, Run<?, ?> build) {
+        super(out, build.getCharset());
+        this.listener = new DefaultBuildAgentErrorListener(build);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionTaskListenerDecoratorFactory.java
+++ b/src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionTaskListenerDecoratorFactory.java
@@ -51,7 +51,7 @@ public class GradleEnterpriseExceptionTaskListenerDecoratorFactory implements Ta
         @Nonnull
         @Override
         public OutputStream decorate(@Nonnull OutputStream logger) {
-            if (isBuildAgentErrorsEnabled()) {
+            if (run != null) {
                 return new GradleEnterpriseExceptionLogProcessor(logger, run);
             }
             return logger;

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
@@ -75,6 +75,11 @@ class BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest exte
         then:
         j.assertLogContains('password=****', secondRun)
         j.assertLogNotContains(secret, secondRun)
+
+        cleanup:
+        System.err.println('---%<--- agent logs')
+        agent.computer.logText.writeLogTo(0, System.err)
+        System.err.println('--->%---')
     }
 
 }

--- a/src/test/groovy/hudson/plugins/gradle/injection/GradleSnippets.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/GradleSnippets.groovy
@@ -32,19 +32,19 @@ class GradleSnippets {
     static WorkflowJob pipelineJobWithCredentials(JenkinsRule j) {
         def pipelineJob = j.createProject(WorkflowJob)
 
-        pipelineJob.setDefinition(new CpsFlowDefinition("""
+        pipelineJob.setDefinition(new CpsFlowDefinition('''
     stage('Build') {
       node('foo') {
         withCredentials([string(credentialsId: 'my-creds', variable: 'PASSWORD')]) {
           if (isUnix()) {
-            sh "echo password=\$PASSWORD"
+            sh 'echo password=$PASSWORD'
           } else {
             bat "echo password=%PASSWORD%"
           }
         }
       }
     }
-""", false))
+''', false))
         return pipelineJob
     }
 


### PR DESCRIPTION
Amends #312 by @alextu. While that appears to have worked, the _way_ in which it worked was not reassuring—an exception is still thrown, but it gets caught and does not break `withCredentials` masking. Better to avoid the exception to begin with. https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/323 proposes to enable `USE_WATCHING` by default, in which case the scenario would apply to all `gradle` plugin users, not only those who are also running `opentelemetry`.

Running

```bash
git checkout gradle-2.8 -- src/main/java/hudson/plugins/gradle/injection/GradleEnterpriseExceptionTaskListenerDecoratorFactory.java
./gradlew -i :test --tests hudson.plugins.gradle.injection.BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest."credentials are always masked in logs"
```

you can see the problem:

```
… org.jenkinsci.plugins.workflow.log.TaskListenerDecorator$DecoratedTaskListener getLogger
WARNING: null
java.lang.IllegalStateException: Expected 1 instance of hudson.plugins.gradle.injection.InjectionConfig but got 0
    at hudson.ExtensionList.lookupSingleton(ExtensionList.java:452)
    at hudson.plugins.gradle.injection.InjectionConfig.get(InjectionConfig.java:81)
    at hudson.plugins.gradle.injection.GradleEnterpriseExceptionTaskListenerDecoratorFactory$GradleEnterpriseExceptionTaskListenerDecorator.decorate(GradleEnterpriseExceptionTaskListenerDecoratorFactory.java:43)
    at org.jenkinsci.plugins.workflow.log.TaskListenerDecorator$MergedTaskListenerDecorator.decorate(TaskListenerDecorator.java:176)
    at org.jenkinsci.plugins.workflow.log.TaskListenerDecorator$DecoratedTaskListener.getLogger(TaskListenerDecorator.java:240)
    at org.jenkinsci.plugins.workflow.log.TaskListenerDecorator$CloseableTaskListener.getLogger(TaskListenerDecorator.java:283)
    at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution$NewlineSafeTaskListener.getLogger(DurableTaskStep.java:455)
    at org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$HandlerImpl.output(DurableTaskStep.java:720)
    at org.jenkinsci.plugins.durabletask.FileMonitoringTask$Watcher.run(FileMonitoringTask.java:616)
```

As [Javadoc](https://javadoc.jenkins.io/plugin/workflow-api/org/jenkinsci/plugins/workflow/log/TaskListenerDecorator.html) says, trying to access controller-only facilities such as `ExtensionList` from within `decorate` is not permitted. In fact the current `GradleEnterpriseExceptionTaskListenerDecorator` could not possibly work remotely because `GradleEnterpriseExceptionLogProcessor` uses `DefaultBuildAgentErrorListener` which can only run inside the controller as currently designed (accessing `Run` objects and so forth). So unless and until that is redesigned to permit it to run inside the agent—ideally by streaming events directly to Gradle Enterprise, but failing that by calling back to the controller somewhat like `TimeoutStep` does ([discussion](https://groups.google.com/g/jenkinsci-dev/c/G13YPY1qr1Q/m/GT9XBMxvBAAJ))—this feature just needs to be suppressed on the log of `sh` steps running remotely.

CC @daniel-beck
