### PR TITLE
Set `gradle.enterprise.externally-applied` before applying GE plugin

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
+++ b/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
@@ -103,7 +103,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (!scanPluginComponent) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                    pluginManager.apply(initscript.classLoader.loadClass(BUILD_SCAN_PLUGIN_CLASS))
+                    applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
@@ -139,7 +139,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
                 logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
                 logger.quiet("Connection to Gradle Enterprise: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                settings.pluginManager.apply(initscript.classLoader.loadClass(GRADLE_ENTERPRISE_PLUGIN_CLASS))
+                applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
@@ -190,4 +190,18 @@ static String escapeChar(char ch) {
 
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
     GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
+}
+
+void applyPluginExternally(PluginManager pluginManager, String pluginClassName) {
+    def oldValue = System.getProperty('gradle.enterprise.externally-applied')
+    System.setProperty('gradle.enterprise.externally-applied', 'true')
+    try {
+        pluginManager.apply(initscript.classLoader.loadClass(pluginClassName))
+    } finally {
+        if (oldValue == null) {
+            System.clearProperty('gradle.enterprise.externally-applied')
+        } else {
+            System.setProperty('gradle.enterprise.externally-applied', oldValue)
+        }
+    }
 }


### PR DESCRIPTION
In order for the Gradle Enterprise plugin to deactivate any potentially build-changing features (at the time of writing that means all of its testing features) when applied via the init script rather than directly in the build, the `gradle.enterprise.externally-applied` system property is now set before applying it and reset afterwards.

<!-- Please describe your pull request here. -->

### Testing done

via Gradle's [`BuildScanPluginSmokeTest`](https://github.com/gradle/gradle/blob/58f73541b54f0dfdb5c04b0c9e4666e88a6b8594/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy) (PR pending)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~Link to relevant issues in GitHub or Jira~
- [x] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
