### PR TITLE
Fix GradleConsoleAnnotator when Timestamper is globally enabled

### DIFF
--- a/src/main/java/hudson/plugins/gradle/GradleOutcomeNote.java
+++ b/src/main/java/hudson/plugins/gradle/GradleOutcomeNote.java
@@ -31,6 +31,8 @@ import hudson.console.ConsoleNote;
 
 import java.util.regex.Pattern;
 
+import static hudson.plugins.gradle.TimestampPrefixDetector.TimestampPattern;
+
 /**
  * Annotates the BUILD SUCCESSFUL/FAILED line of the Ant execution.
  *
@@ -38,7 +40,7 @@ import java.util.regex.Pattern;
  */
 public class GradleOutcomeNote extends ConsoleNote {
 
-    private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("^(BUILD \\S*)");
+    private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("^(?:" + TimestampPattern + ")?(BUILD \\S*)");
 
     public GradleOutcomeNote() {
     }
@@ -49,12 +51,13 @@ public class GradleOutcomeNote extends ConsoleNote {
         if (t == null) {
             return null;
         }
+        int timestampPrefix = TimestampPrefixDetector.detectTimestampPrefix(text.getText());
         String buildStatus = t.group(1);
         if (text.getText().contains("FAIL"))
-            text.addMarkup(0, buildStatus.length(),
+            text.addMarkup(timestampPrefix, timestampPrefix + buildStatus.length(),
                     "<span class=gradle-outcome-failure>", "</span>");
         if (text.getText().contains("SUCCESS"))
-            text.addMarkup(0, buildStatus.length(),
+            text.addMarkup(timestampPrefix, timestampPrefix + buildStatus.length(),
                     "<span class=gradle-outcome-success>", "</span>");
         return null;
     }

--- a/src/main/java/hudson/plugins/gradle/TimestampPrefixDetector.java
+++ b/src/main/java/hudson/plugins/gradle/TimestampPrefixDetector.java
@@ -3,13 +3,16 @@ package hudson.plugins.gradle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-class TimestampPrefixDetector {
+final class TimestampPrefixDetector {
 
     static final String TimestampPattern = "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z\\] ";
     private static final Pattern TimestampPatternR = Pattern.compile("^(" + TimestampPattern + ").*(?:\r?\n)?$");
 
     static String trimTimestampPrefix(int prefix, String line) {
         return line.substring(prefix);
+    }
+
+    private TimestampPrefixDetector() {
     }
 
     static int detectTimestampPrefix(String line) {
@@ -19,6 +22,5 @@ class TimestampPrefixDetector {
         }
         return 0;
     }
-
 
 }

--- a/src/main/java/hudson/plugins/gradle/TimestampPrefixDetector.java
+++ b/src/main/java/hudson/plugins/gradle/TimestampPrefixDetector.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 class TimestampPrefixDetector {
 
     static final String TimestampPattern = "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z\\] ";
-    private static final Pattern TimestampPatternR = Pattern.compile("^(" + TimestampPattern + ").*\n?$");
+    private static final Pattern TimestampPatternR = Pattern.compile("^(" + TimestampPattern + ").*(?:\r?\n)?$");
 
     static String trimTimestampPrefix(int prefix, String line) {
         return line.substring(prefix);

--- a/src/main/java/hudson/plugins/gradle/TimestampPrefixDetector.java
+++ b/src/main/java/hudson/plugins/gradle/TimestampPrefixDetector.java
@@ -1,0 +1,24 @@
+package hudson.plugins.gradle;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class TimestampPrefixDetector {
+
+    static final String TimestampPattern = "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z\\] ";
+    private static final Pattern TimestampPatternR = Pattern.compile("^(" + TimestampPattern + ").*\n?$");
+
+    static String trimTimestampPrefix(int prefix, String line) {
+        return line.substring(prefix);
+    }
+
+    static int detectTimestampPrefix(String line) {
+        Matcher matcher = TimestampPatternR.matcher(line);
+        if (matcher.matches()) {
+            return matcher.group(1).length();
+        }
+        return 0;
+    }
+
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
@@ -43,7 +43,6 @@ class GradleConsoleAnnotatorIntegrationTest extends BaseGradleIntegrationTest {
         def b = j.buildAndAssertSuccess(pipelineJob)
 
         then:
-        println "logs: \n${JenkinsRule.getLog(b)}"
         def client = j.createWebClient()
         def html = client.goTo(b.getUrl() + "console")
         html.getByXPath("//b[@class='gradle-task']")*.textContent*.toString() == [

--- a/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
@@ -4,7 +4,6 @@ import hudson.plugins.timestamper.TimestamperConfig
 import hudson.slaves.DumbSlave
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
-import org.jvnet.hudson.test.JenkinsRule
 
 class GradleConsoleAnnotatorIntegrationTest extends BaseGradleIntegrationTest {
 

--- a/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
@@ -4,6 +4,7 @@ import hudson.plugins.timestamper.TimestamperConfig
 import hudson.slaves.DumbSlave
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jvnet.hudson.test.JenkinsRule
 
 class GradleConsoleAnnotatorIntegrationTest extends BaseGradleIntegrationTest {
 
@@ -42,6 +43,7 @@ class GradleConsoleAnnotatorIntegrationTest extends BaseGradleIntegrationTest {
         def b = j.buildAndAssertSuccess(pipelineJob)
 
         then:
+        println "logs: \n${JenkinsRule.getLog(b)}"
         def client = j.createWebClient()
         def html = client.goTo(b.getUrl() + "console")
         html.getByXPath("//b[@class='gradle-task']")*.textContent*.toString() == [

--- a/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleConsoleAnnotatorIntegrationTest.groovy
@@ -1,0 +1,72 @@
+package hudson.plugins.gradle
+
+import hudson.plugins.timestamper.TimestamperConfig
+import hudson.slaves.DumbSlave
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+
+class GradleConsoleAnnotatorIntegrationTest extends BaseGradleIntegrationTest {
+
+    def 'pipeline job has Gradle tasks annotated'(boolean enableTimestamper) {
+        given:
+        def gradleVersion = '8.1.1'
+        gradleInstallationRule.gradleVersion = gradleVersion
+        gradleInstallationRule.addInstallation()
+
+        DumbSlave agent = createSlave('foo')
+        def pipelineJob = j.createProject(WorkflowJob)
+
+        pipelineJob.setDefinition(new CpsFlowDefinition("""
+    stage('Build') {
+      node('foo') {
+        withGradle {
+          git branch: 'main', url: 'https://github.com/c00ler/simple-gradle-project'
+          def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+          if (isUnix()) {
+            sh "'\${gradleHome}/bin/gradle' clean build --no-daemon --console=plain"
+          } else {
+            bat(/"\${gradleHome}\\bin\\gradle.bat" clean build --no-daemon --console=plain/)
+          }
+        }
+      }
+    }
+""", false))
+
+        if (enableTimestamper) {
+            TimestamperConfig config = TimestamperConfig.get()
+            config.setAllPipelines(true)
+            config.save()
+        }
+
+        when:
+        def b = j.buildAndAssertSuccess(pipelineJob)
+
+        then:
+        def client = j.createWebClient()
+        def html = client.goTo(b.getUrl() + "console")
+        html.getByXPath("//b[@class='gradle-task']")*.textContent*.toString() == [
+            ' Task :clean',
+            ' Task :compileJava',
+            ' Task :processResources',
+            ' Task :classes',
+            ' Task :jar',
+            ' Task :assemble',
+            ' Task :compileTestJava',
+            ' Task :processTestResources',
+            ' Task :testClasses',
+            ' Task :test',
+            ' Task :check',
+            ' Task :build'
+        ]
+        html.getByXPath("//span[@class='gradle-task-progress-status']")*.textContent*.toString() == [
+            'UP-TO-DATE\n',
+            'NO-SOURCE\n',
+            'NO-SOURCE\n'
+        ]
+        html.getByXPath("//span[@class='gradle-outcome-success']")*.textContent*.toString() == ['BUILD SUCCESSFUL']
+
+        where:
+        enableTimestamper << [ true, false ]
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/GradleTaskNoteTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleTaskNoteTest.groovy
@@ -17,15 +17,15 @@ class GradleTaskNoteTest extends Specification {
 
         where:
         consoleOutput             | annotatedOutput
-        ':TASK'                   | ':<b class=gradle-task>TASK</b>'
-        ':TASK UP-TO-DATE'        | ':<b class=gradle-task>TASK</b> <span class=gradle-task-progress-status>UP-TO-DATE</span>'
-        ':TASK SKIPPED'           | ':<b class=gradle-task>TASK</b> <span class=gradle-task-progress-status>SKIPPED</span>'
-        ':TASK FROM-CACHE'        | ':<b class=gradle-task>TASK</b> <span class=gradle-task-progress-status>FROM-CACHE</span>'
-        ':TASK NO-SOURCE'         | ':<b class=gradle-task>TASK</b> <span class=gradle-task-progress-status>NO-SOURCE</span>'
-        ':TASK DUMMY'             | ':<b class=gradle-task>TASK</b> DUMMY'
+        ':TASK'                   | ':<b class="gradle-task">TASK</b>'
+        ':TASK UP-TO-DATE'        | ':<b class="gradle-task">TASK</b> <span class="gradle-task-progress-status">UP-TO-DATE</span>'
+        ':TASK SKIPPED'           | ':<b class="gradle-task">TASK</b> <span class="gradle-task-progress-status">SKIPPED</span>'
+        ':TASK FROM-CACHE'        | ':<b class="gradle-task">TASK</b> <span class="gradle-task-progress-status">FROM-CACHE</span>'
+        ':TASK NO-SOURCE'         | ':<b class="gradle-task">TASK</b> <span class="gradle-task-progress-status">NO-SOURCE</span>'
+        ':TASK DUMMY'             | ':<b class="gradle-task">TASK</b> DUMMY'
         ':::: ERRORS'             | ':::: ERRORS'
-        ':PARENT:TASK'            | ':<b class=gradle-task>PARENT:TASK</b>'
-        ':PARENT:TASK UP-TO-DATE' | ':<b class=gradle-task>PARENT:TASK</b> <span class=gradle-task-progress-status>UP-TO-DATE</span>'
+        ':PARENT:TASK'            | ':<b class="gradle-task">PARENT:TASK</b>'
+        ':PARENT:TASK UP-TO-DATE' | ':<b class="gradle-task">PARENT:TASK</b> <span class="gradle-task-progress-status">UP-TO-DATE</span>'
     }
 
     void 'no annotation when disabled'() {

--- a/src/test/groovy/hudson/plugins/gradle/TimestampPrefixDetectorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/TimestampPrefixDetectorTest.groovy
@@ -1,0 +1,36 @@
+package hudson.plugins.gradle
+
+import spock.lang.Specification
+
+class TimestampPrefixDetectorTest extends Specification {
+
+    def "detect timestamp on line"() {
+        when:
+        def prefix = TimestampPrefixDetector.detectTimestampPrefix(line)
+
+        then:
+        prefix == expected
+
+        where:
+        line                                               | expected
+        '[2023-12-08T10:05:56.488Z] > Task :compileJava'   | 27
+        '[2023-12-08T10:05:56.488Z] > Task :compileJava\n' | 27
+        '[2023-12-08T10:05:56.488Z]> Task :compileJava'    | 0
+        '[2023-12-08T10:05:56] > Task :compileJava'        | 0
+        'some message'                                     | 0
+    }
+
+    def "trim timestamp"() {
+        when:
+        def trimmed = TimestampPrefixDetector.trimTimestampPrefix(prefix, line)
+
+        then:
+        trimmed == expected
+
+        where:
+        line                                             | prefix | expected
+        '[2023-12-08T10:05:56.488Z] > Task :compileJava' | 27     | '> Task :compileJava'
+        '> Task :compileJava'                            | 0      | '> Task :compileJava'
+    }
+
+}


### PR DESCRIPTION
Fixes [JENKINS-72411](https://issues.jenkins.io/browse/JENKINS-72411) by detecting the timestamp prefix and shift the Gradle notes.
It should always be a complete timestamp and its format should not change (afaik it's changed by a formatter later on when displaying the console).

<!-- Please describe your pull request here. -->

### Testing done
- Unit test for detecting the timestamp prefix
- Integration test to check the expected Gradle notes. The left menu could not be part of this test as it's loaded separately with an ajax request. I checked it manually though.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
