### PR TITLE
Apply Develocity Maven extension only if not already applied

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/MavenCoordinates.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenCoordinates.java
@@ -1,0 +1,39 @@
+package hudson.plugins.gradle.injection;
+
+/**
+ * Describes a set of Maven coordinates, represented as a GAV.
+ */
+public final class MavenCoordinates {
+
+    private final String groupId;
+    private final String artifactId;
+    private final String version;
+
+    public MavenCoordinates(String groupId, String artifactId) {
+        this(groupId, artifactId, "unspecified");
+    }
+
+    public MavenCoordinates(String groupId, String artifactId, String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    String groupId() {
+        return groupId;
+    }
+
+    String artifactId() {
+        return artifactId;
+    }
+
+    String version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s:%s", groupId, artifactId, version);
+    }
+
+}

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtensions.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtensions.java
@@ -1,0 +1,71 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.FilePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Represents a Maven extensions XML file, typically present at {@code .mvn/extensions.xml}.
+ */
+final class MavenExtensions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenExtensions.class);
+
+    private static final XPath XPATH = XPathFactory.newInstance().newXPath();
+
+    private static final String EXTENSION_XPATH_EXPR = "/extensions/extension[groupId = '%s' and artifactId = '%s']";
+
+    private final Document document;
+
+    private MavenExtensions(Document document) {
+        this.document = document;
+    }
+
+    static MavenExtensions empty() {
+        return new MavenExtensions(null);
+    }
+
+    static MavenExtensions fromFilePath(FilePath extensionsFile) {
+        try(InputStream inputStream = extensionsFile.read()) {
+            Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(inputStream);
+            document.normalizeDocument();
+
+            return new MavenExtensions(document);
+        } catch (ParserConfigurationException | IOException | InterruptedException| SAXException e) {
+            LOGGER.warn("Failed to parse extensions file: {}", extensionsFile, e);
+            return MavenExtensions.empty();
+        }
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    boolean hasExtension(MavenCoordinates coordinates) {
+        if (document == null || coordinates == null) {
+            return false;
+        }
+
+        String expr = String.format(EXTENSION_XPATH_EXPR, coordinates.groupId(), coordinates.artifactId());
+        try {
+            XPathExpression exprCompiled = XPATH.compile(expr);
+            NodeList extension = (NodeList) exprCompiled.evaluate(document, XPathConstants.NODESET);
+
+            return extension != null && extension.getLength() > 0;
+        } catch (XPathExpressionException e) {
+            LOGGER.warn("Could not apply XPath expression: {}", expr, e);
+            return false;
+        }
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -16,7 +16,7 @@ import org.junit.rules.RuleChain
 abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
 
     public final GradleInstallationRule gradleInstallationRule = new GradleInstallationRule(j)
-    static final String GRADLE_ENTERPRISE_PLUGIN_VERSION = '3.13.4'
+    static final String GRADLE_ENTERPRISE_PLUGIN_VERSION = '3.16.2'
 
     @Rule
     public final RuleChain rules = RuleChain.outerRule(noSpaceInTmpDirs).around(j).around(gradleInstallationRule)

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -23,18 +23,18 @@ import spock.lang.Unroll
 @Unroll
 class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest {
 
-    private static final String CCUD_PLUGIN_VERSION = '1.8.1'
+    private static final String CCUD_PLUGIN_VERSION = '1.12.1'
 
     private static final String MSG_INIT_SCRIPT_APPLIED = "Connection to Develocity: http://foo.com"
 
-    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.1', '8.0.2']
+    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.4', '8.6']
 
     private static final EnvVars EMPTY_ENV = new EnvVars()
 
     def "does not capture build agent errors if checking for errors is disabled"() {
         given:
         System.setProperty(TimestampNote.systemProperty, 'true')
-        def gradleVersion = '8.1.1'
+        def gradleVersion = '8.6'
 
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
@@ -71,7 +71,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
     def "captures build agent errors if checking for errors is enabled"() {
         given:
         System.setProperty(TimestampNote.systemProperty, 'true')
-        def gradleVersion = '8.1.1'
+        def gradleVersion = '8.6'
 
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
@@ -112,7 +112,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "captures build agent errors in pipeline build if checking for errors is enabled"() {
         given:
-        def gradleVersion = '8.1.1'
+        def gradleVersion = '8.6'
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
 
@@ -147,7 +147,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         def secret = 'confidential'
         registerCredentials('my-creds', secret)
 
-        def gradleVersion = '8.1.1'
+        def gradleVersion = '8.6'
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
 
@@ -176,7 +176,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def 'skips injection if the agent is offline'() {
         given:
-        def gradleVersion = '8.0.2'
+        def gradleVersion = '8.6'
 
         def agent = createSlave("test")
 
@@ -515,7 +515,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "doesn't copy init script if already exists"() {
         given:
-        def gradleVersion = '7.5.1'
+        def gradleVersion = '8.6'
 
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
@@ -543,7 +543,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "copies init script if it was changed"() {
         given:
-        def gradleVersion = '7.5.1'
+        def gradleVersion = '8.6'
 
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
@@ -580,7 +580,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
     @SuppressWarnings("GStringExpressionWithinString")
     def "access key is injected into the build"() {
         given:
-        def gradleVersion = '8.0.1'
+        def gradleVersion = '8.6'
 
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
@@ -610,14 +610,14 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         then:
         j.assertLogContains(MSG_INIT_SCRIPT_APPLIED, secondRun)
         j.assertLogContains("accessKey=foo.com=secret", secondRun)
-        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.13.4/token was not from Gradle Enterprise.", secondRun)
+        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.16.2/token was not from Gradle Enterprise.", secondRun)
         j.assertLogNotContains(INVALID_ACCESS_KEY_FORMAT_ERROR, secondRun)
 
     }
 
     def "invalid access key is not injected into the build"() {
         given:
-        def gradleVersion = '8.0.1'
+        def gradleVersion = '8.6'
 
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
@@ -646,7 +646,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         then:
         j.assertLogContains(MSG_INIT_SCRIPT_APPLIED, secondRun)
-        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.13.4/token was not from Gradle Enterprise.", secondRun)
+        j.assertLogContains("The response from http://foo.com/scans/publish/gradle/3.16.2/token was not from Gradle Enterprise.", secondRun)
 
         and:
         StringUtils.countMatches(JenkinsRule.getLog(secondRun), INVALID_ACCESS_KEY_FORMAT_ERROR) == 1
@@ -654,7 +654,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "sets all mandatory environment variables"() {
         given:
-        def gradleVersion = '8.0.2'
+        def gradleVersion = '8.6'
 
         def agent = createSlave("test")
 
@@ -680,7 +680,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         with(agent.getNodeProperty(EnvironmentVariablesNodeProperty.class)) {
             with(getEnvVars()) {
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL") == "http://localhost"
-                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.13.4'
+                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.16.2'
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER") == null
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ENFORCE_URL") == null
                 get("JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL") == null
@@ -714,7 +714,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "sets all optional environment variables"() {
         given:
-        def gradleVersion = '8.0.2'
+        def gradleVersion = '8.6'
 
         def agent = createSlave("test")
 
@@ -745,10 +745,10 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
             with(getEnvVars()) {
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_URL") == "http://localhost"
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ENFORCE_URL") == "true"
-                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.13.4'
+                get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_PLUGIN_VERSION") == '3.16.2'
                 get("JENKINSGRADLEPLUGIN_GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER") == "true"
                 get("JENKINSGRADLEPLUGIN_GRADLE_PLUGIN_REPOSITORY_URL") == "http://localhost/repository"
-                get("JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION") == "1.8.1"
+                get("JENKINSGRADLEPLUGIN_CCUD_PLUGIN_VERSION") == "1.12.1"
             }
         }
 
@@ -780,8 +780,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def 'vcs repository pattern injection for freestyle remote project - #filter #shouldApplyAutoInjection'(String filter, boolean shouldApplyAutoInjection) {
         given:
-        def gradleVersion = '8.0.2'
-        gradleInstallationRule.gradleVersion = '8.0.2'
+        def gradleVersion = '8.6'
+        gradleInstallationRule.gradleVersion = '8.6'
         gradleInstallationRule.addInstallation()
 
         DumbSlave slave = createSlave()
@@ -821,7 +821,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def 'vcs repository pattern injection for pipeline remote project - #filter #shouldApplyAutoInjection'(String filter, boolean shouldApplyAutoInjection) {
         given:
-        def gradleVersion = '8.0.2'
+        def gradleVersion = '8.6'
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
@@ -20,7 +20,7 @@ class BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest exte
     @PendingFeature
     def "cannot capture build agent errors in pipeline build if DurableTaskStep.USE_WATCHING=true"() {
         given:
-        def gradleVersion = '8.1.1'
+        def gradleVersion = '8.6'
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
 
@@ -50,7 +50,7 @@ class BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest exte
         def secret = 'confidential'
         registerCredentials('my-creds', secret)
 
-        def gradleVersion = '8.1.1'
+        def gradleVersion = '8.6'
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenCrossVersionTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenCrossVersionTest.groovy
@@ -56,7 +56,7 @@ class BuildScanInjectionMavenCrossVersionTest extends BaseMavenIntegrationTest {
             '3.5.4',
             '3.6.3',
             '3.8.8',
-            '3.9.1'
+            '3.9.6'
         ]
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -732,7 +732,7 @@ node {
 
         then:
         // Project has localhost:8080 configured
-        j.assertLogContains("[WARNING] No build scan will be published: Gradle Enterprise features were not enabled due to an unexpected error while contacting Gradle Enterprise: 403 Forbidden.", build)
+        j.assertLogContains("[WARNING] No build scan will be published: Gradle Enterprise features were not enabled due to an unexpected error while contacting Gradle Enterprise.", build)
 
         where:
         mavenSetup << ["withEnv([\"PATH+MAVEN=\${tool 'mavenInstallationName'}/bin\"]) {" , "withMaven(maven: 'mavenInstallationName') {"]
@@ -763,7 +763,7 @@ node {
 
         then:
         // Project has localhost:8080 configured
-        j.assertLogContains("[WARNING] No build scan will be published: Gradle Enterprise features were not enabled due to an unexpected error while contacting Gradle Enterprise: 403 Forbidden.", build)
+        j.assertLogContains("[WARNING] No build scan will be published: Gradle Enterprise features were not enabled due to an unexpected error while contacting Gradle Enterprise.", build)
     }
 
     private static void assertMavenConfigClasspathJars(DumbSlave slave, String... jars) {

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsTest.groovy
@@ -1,0 +1,128 @@
+package hudson.plugins.gradle.injection
+
+import hudson.FilePath
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class MavenExtensionsTest extends Specification {
+
+    private static final SOME_EXTENSION_COORDINATES = new MavenCoordinates('com.gradle', 'some-artifact-id', '0.1.0')
+
+    @TempDir
+    File extensionsDir
+    File extensionsXml
+
+    def setup() {
+        extensionsXml = new File(extensionsDir, 'extensions.xml')
+    }
+
+    def 'hasExtension returns false when MavenExtensions is created via empty'() {
+        when:
+        def mavenExtensions = MavenExtensions.empty()
+
+        then:
+        !mavenExtensions.hasExtension(SOME_EXTENSION_COORDINATES)
+    }
+
+    def 'hasExtension returns false when extensions xml file is not present'() {
+        given:
+        extensionsXml.delete()
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        !mavenExtensions.hasExtension(SOME_EXTENSION_COORDINATES)
+    }
+
+    def 'hasExtension returns false when extensions xml file is not valid xml'() {
+        given:
+        extensionsXml << ""
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        !mavenExtensions.hasExtension(SOME_EXTENSION_COORDINATES)
+    }
+
+    def 'hasExtension returns false when coordinates argument is null'() {
+        given:
+        MavenCoordinates nullCoords = null
+        extensionsXml << generateExtensionsXml(SOME_EXTENSION_COORDINATES)
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        !mavenExtensions.hasExtension(nullCoords)
+    }
+
+    def 'hasExtension returns false when coordinates argument has invalid characters for xpath expression'() {
+        given:
+        def coordsWithInvalidCharacters = new MavenCoordinates('com.example', "\'")
+        extensionsXml << generateExtensionsXml(SOME_EXTENSION_COORDINATES)
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        !mavenExtensions.hasExtension(coordsWithInvalidCharacters)
+    }
+
+    def 'hasExtension returns false when only group or artifact of coordinates argument matches'() {
+        given:
+        def coordsInExtensionsXml = new MavenCoordinates('com.gradle', 'some-artifact-id', '0.1.0')
+        def coordsToMatchSameGroup = new MavenCoordinates('com.gradle', 'different-artifact-d')
+        def coordsToMatchSameArtifact = new MavenCoordinates('com.different', 'some-artifact-id')
+        extensionsXml << generateExtensionsXml(coordsInExtensionsXml)
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        !mavenExtensions.hasExtension(coordsToMatchSameGroup)
+        !mavenExtensions.hasExtension(coordsToMatchSameArtifact)
+    }
+
+    def 'hasExtension returns true when group and artifact of coordinates argument matches'() {
+        given:
+        def coordinatesInExtensionsXml = new MavenCoordinates('com.gradle', 'some-artifact-id', '0.1.0')
+        def coordinatesToMatch = new MavenCoordinates('com.gradle', 'some-artifact-id', '0.2.0')
+        extensionsXml << generateExtensionsXml(coordinatesInExtensionsXml)
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        mavenExtensions.hasExtension(coordinatesToMatch)
+    }
+
+    def 'hasExtension returns true when group, artifact, and version of coordinates argument matches'() {
+        given:
+        def coordinatesInExtensionsXml = new MavenCoordinates('com.example', 'example-artifact-id', '0.1.0')
+        extensionsXml << generateExtensionsXml(SOME_EXTENSION_COORDINATES, coordinatesInExtensionsXml)
+
+        when:
+        def mavenExtensions = MavenExtensions.fromFilePath(new FilePath(extensionsXml))
+
+        then:
+        mavenExtensions.hasExtension(SOME_EXTENSION_COORDINATES)
+        mavenExtensions.hasExtension(coordinatesInExtensionsXml)
+    }
+
+    def generateExtensionsXml(MavenCoordinates... extensions) {
+        """<?xml version="1.0" encoding="UTF-8"?>
+            <extensions>
+                ${extensions.collect {
+            extension ->
+                """<extension>
+                           <groupId>${extension.groupId}</groupId>
+                           <artifactId>${extension.artifactId}</artifactId>
+                           <version>${extension.version}</version>
+                       </extension>"""
+        }.join("\n")}
+            </extensions>"""
+    }
+
+}


### PR DESCRIPTION
If a project already has Develocity Maven extension applied, we shouldn't override it with our injection.

If Develocity Maven extension injection is enabled, we will check the `.mvn/extensions.xml` after checkout for the presence of said extension and disable the injection.