### PR TITLE
Disable injection when custom extensions are detected

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
+++ b/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
@@ -384,13 +384,16 @@ public class InjectionConfig extends GlobalConfiguration {
     @Restricted(NoExternalUse.class)
     @POST
     public FormValidation doCheckMavenExtensionCustomCoordinates(@QueryParameter String value) {
-        String coord = Util.fixEmptyAndTrim(value);
-        return coord == null || MavenCoordinates.isValid(coord) ? FormValidation.ok() : FormValidation.error(Messages.InjectionConfig_InvalidMavenExtensionCustomCoordinates());
+        return validateMavenCoordinates(value);
     }
 
     @Restricted(NoExternalUse.class)
     @POST
     public FormValidation doCheckCcudExtensionCustomCoordinates(@QueryParameter String value) {
+        return validateMavenCoordinates(value);
+    }
+
+    private static FormValidation validateMavenCoordinates(String value) {
         String coord = Util.fixEmptyAndTrim(value);
         return coord == null || MavenCoordinates.isValid(coord) ? FormValidation.ok() : FormValidation.error(Messages.InjectionConfig_InvalidMavenExtensionCustomCoordinates());
     }

--- a/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
+++ b/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
@@ -65,6 +65,8 @@ public class InjectionConfig extends GlobalConfiguration {
 
     private boolean injectMavenExtension;
     private boolean injectCcudExtension;
+    private String mavenExtensionCustomCoordinates;
+    private String ccudExtensionCustomCoordinates;
     private ImmutableList<NodeLabelItem> mavenInjectionEnabledNodes;
     private ImmutableList<NodeLabelItem> mavenInjectionDisabledNodes;
 
@@ -235,6 +237,26 @@ public class InjectionConfig extends GlobalConfiguration {
         this.injectMavenExtension = injectMavenExtension;
     }
 
+    @CheckForNull
+    public String getMavenExtensionCustomCoordinates() {
+        return mavenExtensionCustomCoordinates;
+    }
+
+    @DataBoundSetter
+    public void setMavenExtensionCustomCoordinates(String mavenExtensionCustomCoordinates) {
+        this.mavenExtensionCustomCoordinates = Util.fixEmptyAndTrim(mavenExtensionCustomCoordinates);
+    }
+
+    @CheckForNull
+    public String getCcudExtensionCustomCoordinates() {
+        return ccudExtensionCustomCoordinates;
+    }
+
+    @DataBoundSetter
+    public void setCcudExtensionCustomCoordinates(String ccudExtensionCustomCoordinates) {
+        this.ccudExtensionCustomCoordinates = Util.fixEmptyAndTrim(ccudExtensionCustomCoordinates);
+    }
+
     public boolean isInjectCcudExtension() {
         return injectCcudExtension;
     }
@@ -357,6 +379,20 @@ public class InjectionConfig extends GlobalConfiguration {
         return DevelocityAccessKeyValidator.getInstance().isValid(accessKey)
             ? FormValidation.ok()
             : FormValidation.error(Messages.InjectionConfig_InvalidAccessKey());
+    }
+
+    @Restricted(NoExternalUse.class)
+    @POST
+    public FormValidation doCheckMavenExtensionCustomCoordinates(@QueryParameter String value) {
+        String coord = Util.fixEmptyAndTrim(value);
+        return coord == null || MavenCoordinates.isValid(coord) ? FormValidation.ok() : FormValidation.error(Messages.InjectionConfig_InvalidMavenExtensionCustomCoordinates());
+    }
+
+    @Restricted(NoExternalUse.class)
+    @POST
+    public FormValidation doCheckCcudExtensionCustomCoordinates(@QueryParameter String value) {
+        String coord = Util.fixEmptyAndTrim(value);
+        return coord == null || MavenCoordinates.isValid(coord) ? FormValidation.ok() : FormValidation.error(Messages.InjectionConfig_InvalidMavenExtensionCustomCoordinates());
     }
 
     public static FormValidation checkRequiredUrl(String value) {

--- a/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
@@ -2,9 +2,7 @@ package hudson.plugins.gradle.injection;
 
 import hudson.EnvVars;
 import hudson.FilePath;
-import hudson.model.Computer;
 import hudson.model.Node;
-import hudson.plugins.gradle.injection.MavenExtensionsHandler.MavenExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -12,7 +10,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
+
+import static hudson.plugins.gradle.injection.MavenExtClasspathUtils.constructExtClasspath;
+import static hudson.plugins.gradle.injection.MavenExtClasspathUtils.isUnix;
 
 public class MavenBuildScanInjection implements BuildScanInjection, MavenInjectionAware {
 
@@ -112,21 +112,6 @@ public class MavenBuildScanInjection implements BuildScanInjection, MavenInjecti
         }
     }
 
-    private static String constructExtClasspath(List<FilePath> extensions, boolean isUnix) {
-        return extensions
-                .stream()
-                .map(FilePath::getRemote)
-                .collect(Collectors.joining(getDelimiter(isUnix)));
-    }
 
-    private static String getDelimiter(boolean isUnix) {
-        return isUnix ? ":" : ";";
-    }
-
-    private static boolean isUnix(Node node) {
-        Computer computer = node.toComputer();
-
-        return computer == null || Boolean.TRUE.equals(computer.isUnix());
-    }
 
 }

--- a/src/main/java/hudson/plugins/gradle/injection/MavenCoordinates.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenCoordinates.java
@@ -1,11 +1,12 @@
 package hudson.plugins.gradle.injection;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Describes a set of Maven coordinates, represented as a GAV.
  */
-public final class MavenCoordinates {
+public final class MavenCoordinates implements Serializable {
 
     private final String groupId;
     private final String artifactId;

--- a/src/main/java/hudson/plugins/gradle/injection/MavenCoordinates.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenCoordinates.java
@@ -1,5 +1,7 @@
 package hudson.plugins.gradle.injection;
 
+import java.util.Objects;
+
 /**
  * Describes a set of Maven coordinates, represented as a GAV.
  */
@@ -17,6 +19,38 @@ public final class MavenCoordinates {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MavenCoordinates that = (MavenCoordinates) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, version);
+    }
+
+    static MavenCoordinates parseCoordinates(String groupAndArtifact) {
+        if (groupAndArtifact == null || groupAndArtifact.trim().isEmpty()) {
+            return null;
+        } else {
+            String[] ga = groupAndArtifact.split(":");
+            if (ga.length == 2) {
+                return new MavenCoordinates(ga[0], ga[1]);
+            } else if (ga.length == 3) {
+                return new MavenCoordinates(ga[0], ga[1], ga[2]);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    static boolean isValid(String value) {
+        return MavenCoordinates.parseCoordinates(value) != null;
     }
 
     String groupId() {

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtClasspathUtils.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtClasspathUtils.java
@@ -7,8 +7,11 @@ import hudson.model.Node;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class MavenExtClasspathUtils {
+final class MavenExtClasspathUtils {
     static final String SPACE = " ";
+
+    private MavenExtClasspathUtils() {
+    }
 
     static String constructExtClasspath(List<FilePath> extensions, boolean isUnix) {
         return extensions

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtClasspathUtils.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtClasspathUtils.java
@@ -1,0 +1,32 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.FilePath;
+import hudson.model.Computer;
+import hudson.model.Node;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+class MavenExtClasspathUtils {
+    static final String SPACE = " ";
+
+    static String constructExtClasspath(List<FilePath> extensions, boolean isUnix) {
+        return extensions
+            .stream()
+            .map(FilePath::getRemote)
+            .collect(Collectors.joining(getDelimiter(isUnix)));
+    }
+
+    static String getDelimiter(boolean isUnix) {
+        return isUnix ? ":" : ";";
+    }
+
+    static boolean isUnix(Node node) {
+        Computer computer = node.toComputer();
+        return isUnix(computer);
+    }
+
+    static boolean isUnix(Computer computer) {
+        return computer == null || Boolean.TRUE.equals(computer.isUnix());
+    }
+}

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtension.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtension.java
@@ -1,0 +1,32 @@
+package hudson.plugins.gradle.injection;
+
+public enum MavenExtension {
+        GRADLE_ENTERPRISE("gradle-enterprise-maven-extension", ExtensionsVersions.GE_EXTENSION_VERSION, new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension")),
+        CCUD("common-custom-user-data-maven-extension", ExtensionsVersions.CCUD_EXTENSION_VERSION, new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension")),
+        CONFIGURATION("configuration-maven-extension", "1.0.0", new MavenCoordinates("com.gradle", "configuration-maven-extension"));
+
+        private static final String JAR_EXTENSION = ".jar";
+
+        private final String name;
+        private final String version;
+
+        private final MavenCoordinates coordinates;
+
+        MavenExtension(String name, String version, MavenCoordinates coordinates) {
+            this.name = name;
+            this.version = version;
+            this.coordinates = coordinates;
+        }
+
+        public String getTargetJarName() {
+            return name + JAR_EXTENSION;
+        }
+
+        public String getEmbeddedJarName() {
+            return name + "-" + version + JAR_EXTENSION;
+        }
+
+        public MavenCoordinates getCoordinates() {
+            return coordinates;
+        }
+    }

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtensions.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtensions.java
@@ -44,7 +44,7 @@ final class MavenExtensions {
             document.normalizeDocument();
 
             return new MavenExtensions(document);
-        } catch (ParserConfigurationException | IOException | InterruptedException| SAXException e) {
+        } catch (ParserConfigurationException | IOException | InterruptedException | SAXException e) {
             LOGGER.warn("Failed to parse extensions file: {}", extensionsFile, e);
             return MavenExtensions.empty();
         }

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtensionsDetector.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtensionsDetector.java
@@ -1,0 +1,43 @@
+package hudson.plugins.gradle.injection;
+
+import hudson.FilePath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MavenExtensionsDetector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenExtensionsDetector.class);
+
+    static Set<MavenExtension> detect(InjectionConfig config, FilePath workspace) throws IOException, InterruptedException {
+        if (!config.isInjectMavenExtension()) {
+            return Collections.emptySet();
+        }
+
+        FilePath extensionsFile = workspace.child(".mvn/extensions.xml");
+
+        if (extensionsFile.exists()) {
+            LOGGER.debug("Found extensions file: {}", extensionsFile);
+
+            MavenExtensions mavenExtensions = MavenExtensions.fromFilePath(extensionsFile);
+
+            Set<MavenExtension> knownExtensions = new HashSet<>();
+            if (mavenExtensions.hasExtension(MavenExtension.GRADLE_ENTERPRISE.getCoordinates()) ||
+                mavenExtensions.hasExtension(MavenCoordinates.parseCoordinates(config.getMavenExtensionCustomCoordinates()))) {
+                knownExtensions.add(MavenExtension.GRADLE_ENTERPRISE);
+            }
+            if (mavenExtensions.hasExtension(MavenExtension.CCUD.getCoordinates()) ||
+                mavenExtensions.hasExtension(MavenCoordinates.parseCoordinates(config.getCcudExtensionCustomCoordinates()))
+            ) {
+                knownExtensions.add(MavenExtension.CCUD);
+            }
+            return knownExtensions;
+        } else {
+            LOGGER.debug("Extensions file not found: {}", extensionsFile);
+            return Collections.emptySet();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtensionsHandler.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtensionsHandler.java
@@ -82,27 +82,5 @@ public class MavenExtensionsHandler {
         }
     }
 
-    public enum MavenExtension {
-        GRADLE_ENTERPRISE("gradle-enterprise-maven-extension", ExtensionsVersions.GE_EXTENSION_VERSION),
-        CCUD("common-custom-user-data-maven-extension", ExtensionsVersions.CCUD_EXTENSION_VERSION),
-        CONFIGURATION("configuration-maven-extension", "1.0.0");
 
-        private static final String JAR_EXTENSION = ".jar";
-
-        private final String name;
-        private final String version;
-
-        MavenExtension(String name, String version) {
-            this.name = name;
-            this.version = version;
-        }
-
-        public String getTargetJarName() {
-            return name + JAR_EXTENSION;
-        }
-
-        public String getEmbeddedJarName() {
-            return name + "-" + version + JAR_EXTENSION;
-        }
-    }
 }

--- a/src/main/java/hudson/plugins/gradle/injection/MavenOptsDevelocityFilter.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenOptsDevelocityFilter.java
@@ -1,0 +1,70 @@
+package hudson.plugins.gradle.injection;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static hudson.plugins.gradle.injection.MavenExtClasspathUtils.SPACE;
+import static hudson.plugins.gradle.injection.MavenExtClasspathUtils.getDelimiter;
+import static hudson.plugins.gradle.injection.MavenInjectionAware.*;
+
+public class MavenOptsDevelocityFilter {
+
+    // Maven ext classpath is handled separately
+    private final static MavenOptsHandler handler = new MavenOptsHandler(
+        BUILD_SCAN_UPLOAD_IN_BACKGROUND_PROPERTY_KEY,
+        GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY,
+        GRADLE_ENTERPRISE_URL_PROPERTY_KEY
+    );
+    private final Set<MavenExtension> knownExtensionsAlreadyApplied;
+    private final boolean isUnix;
+
+    public MavenOptsDevelocityFilter(Set<MavenExtension> knownExtensionsAlreadyApplied, boolean isUnix) {
+        this.knownExtensionsAlreadyApplied = Sets.immutableEnumSet(knownExtensionsAlreadyApplied);
+        this.isUnix = isUnix;
+    }
+
+    String filter(String mavenOpts, boolean enforceUrl) {
+        mavenOpts = removeKnownExtensionsFromExtClasspath(mavenOpts);
+
+        if (knownExtensionsAlreadyApplied.contains(MavenExtension.GRADLE_ENTERPRISE)) {
+            Set<String> keysToKeep = new HashSet<>();
+            if (enforceUrl) {
+                keysToKeep.add(MavenInjectionAware.GRADLE_ENTERPRISE_URL_PROPERTY_KEY.name);
+            }
+            mavenOpts = Strings.nullToEmpty(handler.removeIfNeeded(mavenOpts, keysToKeep));
+        }
+        return mavenOpts;
+    }
+
+    private String removeKnownExtensionsFromExtClasspath(String mavenOpts) {
+        return Arrays.stream(mavenOpts.split(SPACE))
+            .map(s -> {
+                SystemProperty sysProp = SystemProperty.parse(s);
+                return isMavenExtClasspath(sysProp) ? filterExtClassPath(sysProp) : s;
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(SPACE));
+    }
+
+    private String filterExtClassPath(SystemProperty sysProp) {
+        String cp = Arrays.stream(sysProp.getValue().split(getDelimiter(isUnix)))
+            .filter(lib -> !isKnownExtension(lib))
+            .collect(Collectors.joining(getDelimiter(isUnix)));
+        return cp.isEmpty() ? null : new SystemProperty(MAVEN_EXT_CLASS_PATH_PROPERTY_KEY, cp).asString();
+    }
+
+    private static boolean isMavenExtClasspath(SystemProperty sysProp) {
+        return sysProp != null && MAVEN_EXT_CLASS_PATH_PROPERTY_KEY.name.equals(sysProp.getKey().name);
+    }
+
+    private boolean isKnownExtension(String lib) {
+        return knownExtensionsAlreadyApplied.stream().map(MavenExtension::getTargetJarName).anyMatch(lib::contains);
+    }
+
+}

--- a/src/main/java/hudson/plugins/gradle/injection/SystemProperty.java
+++ b/src/main/java/hudson/plugins/gradle/injection/SystemProperty.java
@@ -1,9 +1,14 @@
 package hudson.plugins.gradle.injection;
 
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public final class SystemProperty {
 
     private final Key key;
     private final String value;
+    private static final Pattern SysPropPattern = Pattern.compile("-D(.*)=(.*)");
 
     public SystemProperty(Key key, String value) {
         this.key = key;
@@ -14,6 +19,36 @@ public final class SystemProperty {
         return String.format("-D%s=%s", key.name, value);
     }
 
+    public Key getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static SystemProperty parse(String sysProp) {
+        Matcher matcher = SysPropPattern.matcher(sysProp);
+        if (matcher.matches()) {
+            return new SystemProperty(Key.optional(matcher.group(1)), matcher.group(2));
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SystemProperty that = (SystemProperty) o;
+        return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
     public static final class Key {
 
         public final String name;
@@ -22,6 +57,19 @@ public final class SystemProperty {
         private Key(String name, boolean required) {
             this.name = name;
             this.required = required;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Key key = (Key) o;
+            return required == key.required && Objects.equals(name, key.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, required);
         }
 
         /**

--- a/src/main/java/hudson/plugins/gradle/injection/SystemProperty.java
+++ b/src/main/java/hudson/plugins/gradle/injection/SystemProperty.java
@@ -6,9 +6,9 @@ import java.util.regex.Pattern;
 
 public final class SystemProperty {
 
+    private static final Pattern SYS_PROP_PATTERN = Pattern.compile("-D(.*)=(.*)");
     private final Key key;
     private final String value;
-    private static final Pattern SysPropPattern = Pattern.compile("-D(.*)=(.*)");
 
     public SystemProperty(Key key, String value) {
         this.key = key;
@@ -28,7 +28,7 @@ public final class SystemProperty {
     }
 
     public static SystemProperty parse(String sysProp) {
-        Matcher matcher = SysPropPattern.matcher(sysProp);
+        Matcher matcher = SYS_PROP_PATTERN.matcher(sysProp);
         if (matcher.matches()) {
             return new SystemProperty(Key.optional(matcher.group(1)), matcher.group(2));
         } else {

--- a/src/main/resources/hudson/plugins/gradle/Messages.properties
+++ b/src/main/resources/hudson/plugins/gradle/Messages.properties
@@ -6,3 +6,5 @@ InjectionConfig.Required=Required.
 InjectionConfig.InvalidUrl=Not a valid URL.
 InjectionConfig.InvalidVersion=Not a valid version.
 InjectionConfig.InvalidAccessKey=Not a valid access key.
+
+InjectionConfig.InvalidMavenExtensionCustomCoordinates=Not a valid Maven groupId:artifactId(:version).

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
@@ -107,6 +107,12 @@
                 <f:entry field="injectCcudExtension">
                     <f:checkbox title="${%Enable Common Custom User Data Maven extension auto-injection}"/>
                 </f:entry>
+                <f:entry title="${%Develocity Maven Extension Custom Coordinates}" field="mavenExtensionCustomCoordinates">
+                    <f:textbox checkMethod="post"/>
+                </f:entry>
+                <f:entry title="${%Common Custom User Data Maven Extension Custom Coordinates}" field="ccudExtensionCustomCoordinates">
+                    <f:textbox checkMethod="post"/>
+                </f:entry>
                 <f:entry title="${%Maven auto-injection enabled nodes}"
                          help="/plugin/gradle/help-mavenInjectionEnabledNodes.html">
                     <f:repeatableProperty field="mavenInjectionEnabledNodes">

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-ccudExtensionCustomCoordinates.html
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-ccudExtensionCustomCoordinates.html
@@ -1,0 +1,3 @@
+<div>
+    The coordinates of a custom Common Custom User Data Maven Extension or of a custom extension that has a transitive dependency on it.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-mavenExtensionCustomCoordinates.html
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-mavenExtensionCustomCoordinates.html
@@ -1,0 +1,3 @@
+<div>
+    The coordinates of a custom extension that has a transitive dependency on the Develocity Maven Extension.
+</div>

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenCoordinatesTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenCoordinatesTest.groovy
@@ -1,0 +1,25 @@
+package hudson.plugins.gradle.injection
+
+import spock.lang.Specification
+
+class MavenCoordinatesTest extends Specification {
+
+    def 'parse coordinates'() {
+        when:
+        def parsed = MavenCoordinates.parseCoordinates(coordinates)
+
+        then:
+        parsed == expected
+
+        where:
+        coordinates              | expected
+        'my.org.foo:bar-app:1.0' | new MavenCoordinates('my.org.foo', 'bar-app', '1.0')
+        'foo:bar'                | new MavenCoordinates('foo', 'bar')
+        'foo'                    | null
+        'foo:bar:1.0:jar'        | null
+        '::'                     | null
+        // probably not what we want
+        ':foo:bar'               | new MavenCoordinates('', 'foo', 'bar')
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsDetectorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsDetectorTest.groovy
@@ -1,0 +1,95 @@
+package hudson.plugins.gradle.injection
+
+import hudson.FilePath
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static hudson.plugins.gradle.injection.MavenExtensionsTest.generateExtensionsXml
+
+class MavenExtensionsDetectorTest extends Specification {
+
+    private static final String DV = 'com.gradle:gradle-enterprise-maven-extension:1.0'
+    private static final String CCUD = 'com.gradle:common-custom-user-data-maven-extension:1.2'
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder()
+
+    def injectionConfig = Mock(InjectionConfig)
+
+    def 'detect DV and CCUD extension'() {
+        given:
+        with(injectionConfig) {
+            injectMavenExtension >> true
+            mavenExtensionCustomCoordinates >> customCoordinates
+            ccudExtensionCustomCoordinates >> ccudCustomCoordinates
+        }
+        def workspace = tempFolder.newFolder('workspace')
+        final FileTreeBuilder dir = new FileTreeBuilder(workspace)
+        dir {
+            '.mvn' {
+                'extensions.xml'(generateExtensionsXml(
+                    *(extensions.collect({ MavenCoordinates.parseCoordinates(it) }))))
+            }
+        }
+
+        when:
+        def detected = MavenExtensionsDetector.detect(injectionConfig, new FilePath(workspace))
+
+        then:
+        detected == expected as Set
+
+        where:
+        customCoordinates | ccudCustomCoordinates | extensions                        | expected
+        null              | null                  | [DV]                              | [MavenExtension.GRADLE_ENTERPRISE]
+        null              | null                  | ['my:ext:1.0']                    | []
+        'my:ext'          | null                  | ['my:ext:2.0']                    | [MavenExtension.GRADLE_ENTERPRISE]
+        'my:ext:1.0'      | null                  | ['my:ext:1.0']                    | [MavenExtension.GRADLE_ENTERPRISE]
+        'my:ext:2.0'      | null                  | ['my:ext:1.0']                    | [MavenExtension.GRADLE_ENTERPRISE]
+        null              | null                  | [CCUD]                            | [MavenExtension.CCUD]
+        null              | 'my:ext-ccud'         | ['my:ext-ccud:1.0']               | [MavenExtension.CCUD]
+        null              | 'my:ext-ccud:1.0'     | ['my:ext-ccud:1.0']               | [MavenExtension.CCUD]
+        null              | 'my:ext-ccud:2.0'     | ['my:ext-ccud:1.0']               | [MavenExtension.CCUD]
+        null              | null                  | [DV, CCUD]                        | [MavenExtension.GRADLE_ENTERPRISE, MavenExtension.CCUD]
+        'my:ext'          | 'my:ext-ccud'         | ['my:ext:1.0', 'my:ext-ccud:1.0'] | [MavenExtension.GRADLE_ENTERPRISE, MavenExtension.CCUD]
+    }
+
+    def 'do not detect DV and CCUD extension when injection is disabled'() {
+        given:
+        with(injectionConfig) {
+            injectMavenExtension >> false
+            mavenExtensionCustomCoordinates >> 'my:ext'
+            ccudExtensionCustomCoordinates >> 'my:ext-ccud'
+        }
+        def workspace = tempFolder.newFolder('workspace')
+        final FileTreeBuilder dir = new FileTreeBuilder(workspace)
+        dir {
+            '.mvn' {
+                'extensions.xml'(
+                    generateExtensionsXml(
+                        MavenCoordinates.parseCoordinates('my:ext:1.0'),
+                        MavenCoordinates.parseCoordinates('my:ext-ccud:1.0')))
+            }
+        }
+
+        when:
+        def detected = MavenExtensionsDetector.detect(injectionConfig, new FilePath(workspace))
+
+        then:
+        detected == [] as Set
+    }
+
+    def 'do not detect DV and CCUD extension when extensions file is not present'() {
+        given:
+        with(injectionConfig) {
+            injectMavenExtension >> true
+        }
+        def workspace = tempFolder.newFolder('workspace')
+
+        when:
+        def detected = MavenExtensionsDetector.detect(injectionConfig, new FilePath(workspace))
+
+        then:
+        detected == [] as Set
+    }
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
@@ -1,7 +1,6 @@
 package hudson.plugins.gradle.injection
 
 import hudson.FilePath
-import hudson.plugins.gradle.injection.MavenExtensionsHandler.MavenExtension
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsTest.groovy
@@ -111,7 +111,7 @@ class MavenExtensionsTest extends Specification {
         mavenExtensions.hasExtension(coordinatesInExtensionsXml)
     }
 
-    def generateExtensionsXml(MavenCoordinates... extensions) {
+    def static generateExtensionsXml(MavenCoordinates... extensions) {
         """<?xml version="1.0" encoding="UTF-8"?>
             <extensions>
                 ${extensions.collect {

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenOptsDevelocityFilterTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenOptsDevelocityFilterTest.groovy
@@ -1,0 +1,99 @@
+package hudson.plugins.gradle.injection
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class MavenOptsDevelocityFilterTest extends Specification {
+
+    private final static DV_SYS_PROPS = '-Dgradle.enterprise.allowUntrustedServer=false ' +
+        '-Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=https://scans.gradle.com'
+    private final static DV_EXT_LIB = '/libs/gradle-enterprise-maven-extension.jar'
+    private final static DV_CCUD_EXT_LIB = '/libs/common-custom-user-data-maven-extension.jar'
+
+    @Unroll("#scenario")
+    def "MAVEN_OPTS should be filtered according to applied extensions"() {
+        given:
+        def mavenOptsFilter = new MavenOptsDevelocityFilter(extensionsAlreadyApplied as Set, true)
+        when:
+        def filtered = mavenOptsFilter.filter(mavenOpts, false)
+
+        then:
+        filtered == expected
+
+        where:
+        scenario << [
+            'DV extension globally injected and DV extension not already applied locally',
+            'DV extension globally injected and DV extension already applied locally',
+            'Random extension globally injected and DV extension already applied locally',
+            'DV extension globally injected amongst others and DV extension already applied locally',
+            'DV+CCUD extensions globally injected and DV+CCUD extensions not already applied locally',
+            'DV+CCUD extensions globally injected and DV+CCUD extensions already applied locally',
+            // A bit more contrieved cases
+            'DV extension globally injected and CCUD extension already applied locally',
+            'DV+CCUD extensions globally injected and CCUD extension already applied locally',
+            'CCUD extensions globally injected and CCUD extension already applied locally',
+        ]
+        mavenOpts << [
+            "-Dmaven.ext.class.path=${DV_EXT_LIB} ${DV_SYS_PROPS}",
+            "-Dmaven.ext.class.path=${DV_EXT_LIB} ${DV_SYS_PROPS}",
+            '-Dmaven.ext.class.path=/libs/some/other/ext.jar',
+            "-Dmaven.ext.class.path=/libs/some/other/ext.jar:${DV_EXT_LIB}:/libs/some/other/ext2.jar ${DV_SYS_PROPS}",
+            "-Dmaven.ext.class.path=${DV_EXT_LIB}:${DV_CCUD_EXT_LIB} ${DV_SYS_PROPS}",
+            "-Dmaven.ext.class.path=${DV_EXT_LIB}:${DV_CCUD_EXT_LIB} ${DV_SYS_PROPS}",
+            "-Dmaven.ext.class.path=${DV_EXT_LIB} ${DV_SYS_PROPS}",
+            "-Dmaven.ext.class.path=${DV_EXT_LIB}:${DV_CCUD_EXT_LIB} ${DV_SYS_PROPS}",
+            "-Dmaven.ext.class.path=${DV_CCUD_EXT_LIB}"
+        ]
+        extensionsAlreadyApplied << [
+            [],
+            [MavenExtension.GRADLE_ENTERPRISE],
+            [MavenExtension.GRADLE_ENTERPRISE],
+            [MavenExtension.GRADLE_ENTERPRISE],
+            [],
+            [MavenExtension.GRADLE_ENTERPRISE, MavenExtension.CCUD],
+            [MavenExtension.CCUD],
+            [MavenExtension.CCUD],
+            [MavenExtension.CCUD]
+        ]
+        expected << [
+            '-Dmaven.ext.class.path=/libs/gradle-enterprise-maven-extension.jar -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=https://scans.gradle.com',
+            '',
+            '',
+            '-Dmaven.ext.class.path=/libs/some/other/ext.jar:/libs/some/other/ext2.jar',
+            '-Dmaven.ext.class.path=/libs/gradle-enterprise-maven-extension.jar:/libs/common-custom-user-data-maven-extension.jar -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=https://scans.gradle.com',
+            '',
+            '-Dmaven.ext.class.path=/libs/gradle-enterprise-maven-extension.jar -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=https://scans.gradle.com',
+            '-Dmaven.ext.class.path=/libs/gradle-enterprise-maven-extension.jar -Dgradle.enterprise.allowUntrustedServer=false -Dgradle.scan.uploadInBackground=false -Dgradle.enterprise.url=https://scans.gradle.com',
+            ''
+        ]
+
+    }
+
+    def "MAVEN_OPTS should be filtered according to applied extensions when enforceUrl is true"() {
+        given:
+        def mavenOptsFilter = new MavenOptsDevelocityFilter(extensionsAlreadyApplied as Set, false)
+
+        when:
+        def filtered = mavenOptsFilter.filter(mavenOpts, true)
+
+        then:
+        filtered == expected
+
+        where:
+        mavenOpts                                                                 | extensionsAlreadyApplied                                | expected
+        "-Dmaven.ext.class.path=${DV_EXT_LIB} ${DV_SYS_PROPS}"                    | [MavenExtension.GRADLE_ENTERPRISE]                      | '-Dgradle.enterprise.url=https://scans.gradle.com'
+        "-Dmaven.ext.class.path=${DV_EXT_LIB}:${DV_CCUD_EXT_LIB} ${DV_SYS_PROPS}" | [MavenExtension.GRADLE_ENTERPRISE, MavenExtension.CCUD] | '-Dgradle.enterprise.url=https://scans.gradle.com'
+    }
+
+    def 'MAVEN_OPTS should be filtered on Windows'() {
+        given:
+        def mavenOptsFilter = new MavenOptsDevelocityFilter([MavenExtension.GRADLE_ENTERPRISE] as Set, false)
+
+        when:
+        def filtered = mavenOptsFilter.filter("-Dmaven.ext.class.path=/libs/some/other/ext.jar;${DV_EXT_LIB};/libs/some/other/ext2.jar ${DV_SYS_PROPS}", false)
+
+        then:
+        filtered == '-Dmaven.ext.class.path=/libs/some/other/ext.jar;/libs/some/other/ext2.jar'
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/SystemPropertyTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/SystemPropertyTest.groovy
@@ -1,0 +1,21 @@
+package hudson.plugins.gradle.injection
+
+import spock.lang.Specification
+
+class SystemPropertyTest extends Specification {
+
+    def 'parse'() {
+        when:
+        def parsed = SystemProperty.parse(sysProp)
+
+        then:
+        parsed == expected
+
+        where:
+        sysProp     | expected
+        '-Dfoo=bar' | new SystemProperty(SystemProperty.Key.optional('foo'), 'bar')
+        'foo=bar'   | null
+        '-Dfoo='    | new SystemProperty(SystemProperty.Key.optional('foo'), '')
+    }
+
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Follow up of https://github.com/jenkinsci/gradle-plugin/pull/393

This PR adds 2 new fields to the Develocity Maven injection:

<img width="1564" alt="image" src="https://github.com/jenkinsci/gradle-plugin/assets/736523/8ef309e5-ebb0-4015-877e-2f28328cd0cc">

Those are used in case built projects have defined custom Develocity derived extensions:
- If the user specifies a GAV in "Develocity Maven Extension Custom Coordinates" field, the Develocity injection will be disabled if a corresponding extension is found in `.mvn/extensions` of the currently built project.
- Similarly, if the user specifies a GAV in "Common Custom User Data Maven Extension Custom Coordinates" field, the CCUD injection will be disabled if a corresponding extension is found in `.mvn/extensions` of the currently built project.

It's a bit complex in terms of implementation since we need to parse the existing `MAVEN_OPTS` looking for the maven ext classpath system property, and filter it accordingly.
We might want to revisit this since it looks like the `ScmListener` we use is called in many cases, even when no Scm is configured...


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
Unit tests and a few integration tests. Some cases cannot easily be setup as integration tests since they would require "real" custom Develocity extensions.
I also tested manually the 2 cases:
- custom extension defined in the built project and corresponding "Develocity Maven Extension Custom Coordinates" field set => DV extension is not applied. The CCUD extension is still applied if "Enable Common Custom User Data Maven extension auto-injection" is checked.
- custom extension defined in the built project and corresponding "Common Custom User Data Maven Extension Custom Coordinates" field set => CCUD extension is not applied. Note that the DV extension is still applied, although most likely, it should also be defined locally; in that case, it's not applied.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
