### PR TITLE
Fix task input files capturing for Gradle 5.x in afterevaluate

### DIFF
--- a/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
+++ b/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
@@ -36,6 +36,7 @@ initscript {
             maven {
                 url pluginRepositoryUrl
                 if (gradlePluginRepoUsername && gradlePluginRepoPassword) {
+                    logger.lifecycle("Using credentials for plugin repository")
                     credentials {
                         username(gradlePluginRepoUsername)
                         password(gradlePluginRepoPassword)
@@ -95,6 +96,7 @@ def geEnforceUrl = Boolean.parseBoolean(getInputParam('jenkinsGradlePlugin.gradl
 def gePluginVersion = getInputParam('jenkinsGradlePlugin.gradle-enterprise.plugin.version')
 def ccudPluginVersion = getInputParam('jenkinsGradlePlugin.ccud.plugin.version')
 
+def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
 // finish early if configuration parameters passed in via system properties are not valid/supported
@@ -120,11 +122,11 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1')) {
-                        if (isNotAtLeast(gePluginVersion, '3.7')) {
-                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        } else {
+                    if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                        if (isAtLeast(gePluginVersion, '3.7')) {
                             buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = false  // uploadInBackground not available for build-scan-plugin 1.16
@@ -137,12 +139,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                            if (isAtLeast(gePluginVersion, '2.1')) {
-                                if (isNotAtLeast(gePluginVersion, '3.7')) {
-                                    buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                                } else {
-                                    buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                                }
+                        }
+                        if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                            if (isAtLeast(gePluginVersion, '3.7')) {
+                                buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                            } else {
+                                buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                             }
                         }
                     }
@@ -173,10 +175,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = false
                     if (isAtLeast(gePluginVersion, '2.1')) {
-                        if (isNotAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        } else {
+                        if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
@@ -189,10 +191,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     if (isAtLeast(gePluginVersion, '2.1')) {
-                        if (isNotAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        } else {
+                        if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                 }

--- a/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
+++ b/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
@@ -122,7 +122,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                         } else {
@@ -140,7 +140,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
-                        if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                        if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
                             if (isAtLeast(gePluginVersion, '3.7')) {
                                 buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                             } else {
@@ -174,7 +174,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = false
-                    if (isAtLeast(gePluginVersion, '2.1')) {
+                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1')) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                         } else {
@@ -190,7 +190,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
-                    if (isAtLeast(gePluginVersion, '2.1')) {
+                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1')) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                         } else {

--- a/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
+++ b/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
@@ -122,13 +122,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
-                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                        if (isAtLeast(gePluginVersion, '3.7')) {
-                            buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                        } else {
-                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        }
-                    }
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = false  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
@@ -140,12 +133,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
-                        if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                            if (isAtLeast(gePluginVersion, '3.7')) {
-                                buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                            } else {
-                                buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                            }
+                    }
+                }
+
+                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                        logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        if (isAtLeast(gePluginVersion, '3.7')) {
+                            buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                 }
@@ -174,13 +171,6 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = false
-                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1')) {
-                        if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                        } else {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        }
-                    }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
             }
@@ -190,12 +180,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
-                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1')) {
-                        if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                        } else {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        }
+                }
+            }
+
+            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
+                if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1')) {
+                    logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                    if (isAtLeast(gePluginVersion, '3.7')) {
+                        ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                    } else {
+                        ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                     }
                 }
             }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -942,7 +942,9 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         then:
         def log = JenkinsRule.getLog(secondRun)
         log.contains('Connection to Develocity: http://foo.com, allowUntrustedServer: false, captureTaskInputFiles: true')
-        log.contains('Setting captureTaskInputFiles: true')
+        if (gradleVersion > '5.0') {
+            assert log.contains('Setting captureTaskInputFiles: true')
+        }
 
         where:
         gradleVersion << GRADLE_VERSIONS

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -942,6 +942,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         then:
         def log = JenkinsRule.getLog(secondRun)
         log.contains('Connection to Develocity: http://foo.com, allowUntrustedServer: false, captureTaskInputFiles: true')
+        log.contains('Setting captureTaskInputFiles: true')
 
         where:
         gradleVersion << GRADLE_VERSIONS


### PR DESCRIPTION
This PR fixes the task input files capturing for Gradle 5.x in afterevaluate block when enforce URL option is chosen (we simply move it out of that block)