### PR TITLE
Capture goal/task input files by default

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
@@ -83,9 +83,8 @@ public class MavenBuildScanInjection implements BuildScanInjection, MavenInjecti
             if (config.isAllowUntrusted()) {
                 systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY, "true"));
             }
-            if (config.isMavenCaptureGoalInputFiles()) {
-                systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_CAPTURE_GOAL_INPUT_FILES_PROPERTY_KEY, "true"));
-            }
+
+            systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_CAPTURE_GOAL_INPUT_FILES_PROPERTY_KEY, Boolean.toString(config.isMavenCaptureGoalInputFiles())));
 
             EnvUtil.setEnvVar(node, MavenOptsHandler.MAVEN_OPTS, MAVEN_OPTS_HANDLER.merge(node, systemProperties));
 

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
@@ -99,7 +99,7 @@
                     </f:repeatableProperty>
                 </f:entry>
                 <f:entry field="gradleCaptureTaskInputFiles">
-                    <f:checkbox title="${%Capture Task Input Files}"/>
+                    <f:checkbox title="${%Capture Task Input Files}" default="true"/>
                 </f:entry>
             </f:section>
 
@@ -137,7 +137,7 @@
                     </f:repeatableProperty>
                 </f:entry>
                 <f:entry field="mavenCaptureGoalInputFiles">
-                    <f:checkbox title="${%Capture Goal Input Files}"/>
+                    <f:checkbox title="${%Capture Goal Input Files}" default="true"/>
                 </f:entry>
             </f:section>
 

--- a/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
+++ b/src/main/resources/hudson/plugins/gradle/injection/init-script.gradle
@@ -117,32 +117,29 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 }
                 if (!scanPluginComponent) {
                     logger.lifecycle("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
-                    logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                    logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     buildScan.server = geUrl
                     buildScan.allowUntrustedServer = geAllowUntrustedServer
                     buildScan.publishAlways()
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = false  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
-                }
-
-                if (geUrl && geEnforceUrl) {
-                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                        afterEvaluate {
-                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
-                            buildScan.server = geUrl
-                            buildScan.allowUntrustedServer = geAllowUntrustedServer
-                        }
-                    }
-                }
-
-                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                    if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                    if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
                         logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                         } else {
                             buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                        }
+                    }
+                }
+
+                if (geUrl && geEnforceUrl) {
+                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                        afterEvaluate {
+                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                            buildScan.server = geUrl
+                            buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
                     }
                 }
@@ -164,7 +161,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
         if (gePluginVersion) {
             if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
                 logger.lifecycle("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
-                logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                 applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
                     ext.server = geUrl
@@ -172,25 +169,22 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = false
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                    if (isAtLeast(gePluginVersion, '2.1')) {
+                        logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        if (isAtLeast(gePluginVersion, '3.7')) {
+                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                        }
+                    }
                 }
             }
 
             if (geUrl && geEnforceUrl) {
                 extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
-                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
-                }
-            }
-
-            extensionsWithPublicType(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS).collect { settings[it.name] }.each { ext ->
-                if (geCaptureTaskInputFiles && isAtLeast(gePluginVersion, '2.1')) {
-                    logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
-                    if (isAtLeast(gePluginVersion, '3.7')) {
-                        ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                    } else {
-                        ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                    }
                 }
             }
         }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -941,7 +941,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         then:
         def log = JenkinsRule.getLog(secondRun)
-        log.contains('Connection to Develocity: http://foo.com, allowUntrustedServer: false, captureTaskInputFiles: true')
+        log.contains('Connection to Develocity: http://foo.com, allowUntrustedServer: false')
         if (gradleVersion > '5.0') {
             assert log.contains('Setting captureTaskInputFiles: true')
         }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -162,6 +162,9 @@ class BuildScanInjectionMavenIntegrationTest extends BaseMavenIntegrationTest {
             with(it.next()) {
                 it == '-Dgradle.enterprise.url=https://scans.gradle.com'
             }
+            with(it.next()) {
+                it == '-Dgradle.scan.captureGoalInputFiles=false'
+            }
             !it.hasNext()
         }
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -163,7 +163,7 @@ class BuildScanInjectionMavenIntegrationTest extends BaseMavenIntegrationTest {
                 it == '-Dgradle.enterprise.url=https://scans.gradle.com'
             }
             with(it.next()) {
-                it == '-Dgradle.scan.captureGoalInputFiles=false'
+                it == '-Dgradle.scan.captureGoalInputFiles=true'
             }
             !it.hasNext()
         }
@@ -983,7 +983,7 @@ node {
         restartSlave(slave)
     }
 
-    void turnOnBuildInjectionAndRestart(DumbSlave slave, Boolean useCCUD = true, boolean captureGoalInputFiles = false) {
+    void turnOnBuildInjectionAndRestart(DumbSlave slave, Boolean useCCUD = true, boolean captureGoalInputFiles = true) {
         withInjectionConfig {
             enabled = true
             server = 'https://scans.gradle.com'


### PR DESCRIPTION
Capturing of goal/task input files is now enabled by default. This is done by pre-selecting the corresponding checkbox in UI with the default value `true`.

The functionality is also only applied for cases where gradle plugin/maven extension isn't already applied.