### PR TITLE
Use Library Plugins for okhttp, jackson

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ val gradlePluginJpi: Configuration by configurations.creating { isCanBeConsumed 
 dependencies {
     api(platform("io.jenkins.tools.bom:bom-${coreBaseVersion}.x:${coreBomVersion}"))
 
+    implementation("org.jenkins-ci.plugins:jackson2-api")
     implementation("org.jenkins-ci.plugins:structs")
     implementation("org.jenkins-ci.plugins.workflow:workflow-api")
     implementation("org.jenkins-ci.plugins.workflow:workflow-cps")
@@ -99,6 +100,7 @@ dependencies {
     implementation("org.jenkins-ci.plugins.workflow:workflow-basic-steps")
     implementation("org.jenkins-ci.plugins.workflow:workflow-durable-task-step")
     implementation("org.jenkins-ci.plugins.workflow:workflow-step-api")
+    implementation("io.jenkins.plugins:okhttp-api")
 
     "optionalPluginImplementation"("org.jenkins-ci.main:maven-plugin:3.14") {
         because("Lowest version that works with our dependencies")
@@ -113,10 +115,6 @@ dependencies {
         exclude(group = "commons-beanutils", module = "commons-beanutils")
         exclude(group = "commons-logging", module = "commons-logging")
     }
-
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.1")
-
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     add(includedLibs.name, "com.gradle:develocity-maven-extension:${develocityMavenExtensionVersion}")
     add(includedLibs.name, "com.gradle:common-custom-user-data-maven-extension:${commonCustomUserDataMavenExtensionVersion}")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Hi! This updates the plugin to depend on the api-plugin versions of okhttp and jackson. This is a [recommended approach](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#using-library-wrapper-plugins) to code sharing.

I have a few plugins that depend on `gradle` and `okhttp-api`. I'm currently pinning back to Gradle 2.11 because 2.12 brings in its own copy of okhttp (https://github.com/jenkinsci/gradle-plugin/pull/426), causing runtime errors on startup.

While `okhttp-api` alone would fix the problem for me, I included jackson2 because it has the same guidance.

Thanks for taking a look!

### Testing done

Existing tests pass after the change.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
