### PR TITLE
Update Jenkins min version and adapt build

### DIFF
--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -45,7 +45,7 @@ val currentJava = JavaVersion.current()
 val jenkinsVersions = listOf(
     JenkinsVersion.LATEST,
     JenkinsVersion.LATEST_LTS,
-    JenkinsVersion.V2_375
+    JenkinsVersion.V2_401
 )
 
 jenkinsVersions
@@ -113,17 +113,18 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL, val javaVer
 
         private const val LATEST_VERSION = "latest"
         private const val LATEST_LTS_VERSION = "latest-lts"
-        private const val V2_388_VERSION = "2.388"
+        private const val V2_401_VERSION = "2.401.3"
 
         private const val MIRROR = "https://updates.jenkins.io"
 
         private val JENKINS_VERSION_PATTERN = "^\\d+([.]\\d+)*?\$".toRegex()
 
         private val JAVA_11 = JavaLanguageVersion.of(11)
+        private val JAVA_17 = JavaLanguageVersion.of(17)
 
-        val LATEST = of(LATEST_VERSION)
+        val LATEST = of(LATEST_VERSION, JAVA_17)
         val LATEST_LTS = of(LATEST_LTS_VERSION)
-        val V2_375 = of(V2_388_VERSION)
+        val V2_401 = of(V2_401_VERSION)
 
         private fun of(version: String, javaVersion: JavaLanguageVersion = JAVA_11): JenkinsVersion {
             val downloadUrl =
@@ -145,7 +146,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL, val javaVer
     }
 
     val isDefault: Boolean
-        get() = version == V2_388_VERSION
+        get() = version == V2_401_VERSION
 
     val label: String
         get() = if (isJenkinsVersion(version)) {

--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/MavenInjectionTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/MavenInjectionTest.java
@@ -1,7 +1,6 @@
 package hudson.plugins.gradle;
 
 import com.google.common.collect.ImmutableMap;
-import hudson.plugin.gradle.ath.updatecenter.WithVersionOverrides;
 import org.apache.commons.text.StringSubstitutor;
 import org.jenkinsci.test.acceptance.junit.WithOS;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
@@ -52,28 +51,6 @@ public class MavenInjectionTest extends AbstractAcceptanceTest {
         // then
         build.shouldSucceed();
         assertBuildScanPublished(build);
-    }
-
-    @Test
-    @WithVersionOverrides("maven-plugin=3.14")
-    @WithPlugins("maven-plugin")
-    @Ignore("https://github.com/gradle/dv/issues/35892")
-    public void autoInjectionSkippedWhenOldMavenPlugin() {
-        // given
-        MavenModuleSet job = jenkins.jobs.create(MavenModuleSet.class);
-
-        job.configure();
-        job.copyDir(resource("/simple_maven_project"));
-        job.goals.set("clean compile");
-
-        job.save();
-
-        // when
-        Build build = job.startBuild();
-
-        // then
-        build.shouldSucceed();
-        assertBuildScanNotPublished(build);
     }
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,10 +11,6 @@ include("configuration-maven-extension")
 
 rootProject.name = "gradle-plugin"
 
-if (!JavaVersion.current().isJava11) {
-    throw GradleException("Build requires Java 11")
-}
-
 val gradleExt = (gradle as ExtensionAware).extra
 
 val ciJenkinsBuild by gradleExt { System.getenv("JENKINS_URL") != null }

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -71,7 +71,7 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
         if(Functions.isWindows()) {
             try {
                 println 'Killing Gradle processes'
-                def proc = '''WMIC PROCESS where "Name like 'java%' AND CommandLine like '%GradleDaemon%'" Call Terminate"'''.execute()
+                def proc = '''WMIC PROCESS where "Name like 'java%%' AND CommandLine like '%%GradleDaemon%%'" Call Terminate"'''.execute()
                 proc.waitFor(30, TimeUnit.SECONDS)
                 println "output: ${proc.text}"
                 println "code: ${proc.exitValue()}"

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -67,6 +67,7 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), creds)
     }
 
+    @SuppressWarnings("CatchException")
     def cleanup() {
         if(Functions.isWindows()) {
             try {

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -3,12 +3,15 @@ package hudson.plugins.gradle
 import com.cloudbees.plugins.credentials.CredentialsProvider
 import com.cloudbees.plugins.credentials.CredentialsScope
 import com.cloudbees.plugins.credentials.domains.Domain
+import hudson.Functions
 import hudson.slaves.DumbSlave
 import hudson.util.Secret
 import org.jenkinsci.plugins.plaincredentials.StringCredentials
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
 import org.junit.Rule
 import org.junit.rules.RuleChain
+
+import java.util.concurrent.TimeUnit
 
 /**
  * Base class for tests that need a Jenkins instance and Gradle tool.
@@ -62,6 +65,21 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
     def registerCredentials(String id, String secret) {
         StringCredentials creds = new StringCredentialsImpl(CredentialsScope.GLOBAL, id, null, Secret.fromString(secret))
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), creds)
+    }
+
+    def cleanup() {
+        if(Functions.isWindows()) {
+            try {
+                println 'Killing Gradle processes'
+                def proc = '''WMIC PROCESS where "Name like 'java%' AND CommandLine like '%GradleDaemon%'" Call Terminate"'''.execute()
+                proc.waitFor(30, TimeUnit.SECONDS)
+                println "output: ${proc.text}"
+                println "code: ${proc.exitValue()}"
+            } catch (Exception e) {
+                System.err.println('Failed killing Gradle daemons')
+                e.printStackTrace()
+            }
+        }
     }
 
 }

--- a/src/test/groovy/hudson/plugins/gradle/BuildScanIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BuildScanIntegrationTest.groovy
@@ -1,6 +1,7 @@
 package hudson.plugins.gradle
 
 import hudson.model.FreeStyleProject
+import hudson.model.JDK
 import hudson.plugins.gradle.injection.MavenSnippets
 import hudson.plugins.timestamper.TimestamperBuildWrapper
 import hudson.tasks.BatchFile
@@ -13,16 +14,23 @@ import org.jvnet.hudson.test.CreateFileBuilder
 import org.jvnet.hudson.test.ExtractResourceSCM
 import org.jvnet.hudson.test.JenkinsRule
 import org.jvnet.hudson.test.ToolInstallations
+import spock.lang.Requires
 import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @Unroll
 @SuppressWarnings("GStringExpressionWithinString")
 class BuildScanIntegrationTest extends BaseGradleIntegrationTest {
+    private static final String JDK8_SYS_PROP = 'jdk8.home'
 
+    @Requires(value = { hasJdk8() }, reason = "Gradle 3 and 4 require Java 8")
     def 'build scans for plugin version #buildScanVersion is discovered'() {
         given:
         gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        setJdk8()
         FreeStyleProject p = j.createFreeStyleProject()
         p.buildersList.add(buildScriptBuilder(buildScanVersion))
         p.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "${args} --no-daemon"))
@@ -251,14 +259,15 @@ stage('Final') {
         new URL(action.scanUrls.get(0))
     }
 
+    @Requires(value = { hasJdk8() }, reason = "Gradle 3 and 4 require Java 8")
     def 'build scan action is exposed via rest API'() {
         given:
         gradleInstallationRule.gradleVersion = '3.4'
         gradleInstallationRule.addInstallation()
+        setJdk8()
         FreeStyleProject p = j.createFreeStyleProject()
         p.buildersList.add(buildScriptBuilder('1.8'))
         p.buildersList.add(new Gradle(tasks: 'hello', gradleName: '3.4', switches: '-Dscan --no-daemon'))
-
 
         when:
         def build = j.buildAndAssertSuccess(p)
@@ -305,4 +314,14 @@ tasks.register("hello") { doLast { println("Hello") } }''')
     private static CreateFileBuilder settingsScriptBuilder(String gePluginVersion) {
         return new CreateFileBuilder('settings.gradle', "plugins { id 'com.gradle.enterprise' version '${gePluginVersion}' }")
     }
+
+    private setJdk8() {
+        j.jenkins.setJDKs(Collections.singleton(new JDK('JDK8', System.getProperty(JDK8_SYS_PROP))))
+    }
+
+    private static hasJdk8() {
+        def jdk8SysProp = System.getProperty(JDK8_SYS_PROP)
+        return jdk8SysProp && Files.exists(Paths.get(jdk8SysProp))
+    }
+
 }

--- a/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -24,9 +24,6 @@
 
 package hudson.plugins.gradle
 
-import com.gargoylesoftware.htmlunit.html.HtmlButton
-import com.gargoylesoftware.htmlunit.html.HtmlForm
-import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.google.common.base.Joiner
 import hudson.EnvVars
 import hudson.model.FreeStyleBuild
@@ -34,6 +31,9 @@ import hudson.model.FreeStyleProject
 import hudson.model.Result
 import hudson.tools.InstallSourceProperty
 import hudson.util.VersionNumber
+import org.htmlunit.html.HtmlButton
+import org.htmlunit.html.HtmlForm
+import org.htmlunit.html.HtmlPage
 import org.jvnet.hudson.test.CreateFileBuilder
 import org.jvnet.hudson.test.JenkinsRule.WebClient
 import spock.lang.Unroll

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -363,6 +363,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
             sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
           } else {
             bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
+            bat(/"\${gradleHome}\\bin\\gradle.bat" --stop/)
           }
         }
       }
@@ -859,6 +860,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
             sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
           } else {
             bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
+            bat(/"\${gradleHome}\\bin\\gradle.bat" --stop/)
           }
         }
       }

--- a/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigTest.groovy
@@ -1,11 +1,11 @@
 package hudson.plugins.gradle.injection
 
-import com.gargoylesoftware.htmlunit.html.HtmlButton
-import com.gargoylesoftware.htmlunit.html.HtmlForm
 import hudson.plugins.gradle.BaseJenkinsIntegrationTest
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import hudson.util.FormValidation
 import hudson.util.XStream2
+import org.htmlunit.html.HtmlButton
+import org.htmlunit.html.HtmlForm
 import spock.lang.Shared
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -311,7 +311,7 @@ class InjectionConfigTest extends BaseJenkinsIntegrationTest {
     }
 
     private static HtmlButton getAddButton(HtmlForm form, String label) {
-        def xpath = "//div[contains(@class, 'setting-name') and text() = '$label']/following-sibling::div[contains(@class, 'setting-main')]//span[contains(@class, 'repeatable-add')]//button[text() = 'Add']"
+        def xpath = "//div[text() = '$label']/following-sibling::div[contains(@class, 'setting-main')]//span[contains(@class, 'repeatable-add')]//button[text() = 'Add']"
         return form.getFirstByXPath(xpath)
     }
 }


### PR DESCRIPTION
This PR updates various versions:
- Latest Jenkins requires Java 17 or above
- Recently added plugin dependencies (jackson) require Jenkins 2.401.3 and Jenkins 2.401.3 requires Java 11 or above.
- Animal Sniffer is unnecessary with Java 11, replaced by compileJava `options.release = 11`
- Test harness is upgraded to fix some tests failures

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
