### PR TITLE
Migrate secrets to credentials plugin and add custom Maven Repository

### DIFF
--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/AbstractAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/AbstractAcceptanceTest.java
@@ -117,9 +117,7 @@ public abstract class AbstractAcceptanceTest extends AbstractJUnitTest {
     }
 
     protected final void setGradlePluginRepositoryPassword(String password) {
-        updateBuildScansInjectionSettings(settings -> {
-            settings.setGradleEnterpriseGradlePluginRepoPassword(password);
-        });
+        updateBuildScansInjectionSettings(settings -> settings.setGradleEnterpriseGradlePluginRepoPassword(password));
     }
 
     private void updateBuildScansInjectionSettings(Consumer<BuildScansInjectionSettings> spec) {

--- a/src/main/java/hudson/plugins/gradle/injection/MavenExtension.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenExtension.java
@@ -1,11 +1,14 @@
 package hudson.plugins.gradle.injection;
 
 public enum MavenExtension {
+
     DEVELOCITY("develocity-maven-extension", new MavenCoordinates("com.gradle", "develocity-maven-extension")),
     GRADLE_ENTERPRISE("gradle-enterprise-maven-extension", new MavenCoordinates("com.gradle", "gradle-enterprise-maven-extension")),
     CCUD("common-custom-user-data-maven-extension", new MavenCoordinates("com.gradle", "common-custom-user-data-maven-extension")),
     CONFIGURATION("configuration-maven-extension", new MavenCoordinates("com.gradle", "configuration-maven-extension"));
 
+    private static final String EXTENSION_REPOSITORY_PATH = "/com/gradle/%s/%s/%s-%s.jar";
+    private static final String DEFAULT_REPOSITORY_URL = "https://repo1.maven.org/maven2" + EXTENSION_REPOSITORY_PATH;
     private static final String JAR_EXTENSION = ".jar";
     private static final String LAST_GRADLE_ENTERPRISE_VERSION = "1.20.1";
 
@@ -35,7 +38,36 @@ public enum MavenExtension {
         return name;
     }
 
-    public static boolean isDevelocityExtensionVersion(String version) {
-        return version.compareTo(LAST_GRADLE_ENTERPRISE_VERSION) > 0;
+    public static MavenExtension getDevelocityMavenExtension(String version) {
+        return version.compareTo(LAST_GRADLE_ENTERPRISE_VERSION) > 0 ? DEVELOCITY : GRADLE_ENTERPRISE;
     }
+
+    public String createDownloadUrl(String version, String repositoryUrl) {
+        if (repositoryUrl == null || InjectionUtil.isInvalid(InjectionConfig.checkUrl(repositoryUrl))) {
+            repositoryUrl = DEFAULT_REPOSITORY_URL;
+        }
+
+        return String.format(repositoryUrl, this.getName(), version, this.getName(), version);
+    }
+
+    public static final class RepositoryCredentials {
+
+        private final String username;
+        private final String password;
+
+        public RepositoryCredentials(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        public String username() {
+            return username;
+        }
+
+        public String password() {
+            return password;
+        }
+
+    }
+
 }

--- a/src/main/java/hudson/plugins/gradle/injection/token/ShortLivedTokenClient.java
+++ b/src/main/java/hudson/plugins/gradle/injection/token/ShortLivedTokenClient.java
@@ -10,11 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:c="/lib/credentials">
     <f:section title="${%Develocity integration}">
         <f:optionalBlock field="enabled" title="${%Enable auto-injection}" inline="true">
 
@@ -33,13 +33,13 @@
                 <f:entry field="enforceUrl">
                     <f:checkbox title="${%Enforce Develocity server url}"/>
                 </f:entry>
-                <f:entry title="${%Develocity access key}" field="accessKey">
+                <f:entry title="Develocity Access Key Credential ID" field="accessKeyCredentialId">
                     <div class="alert alert-info" role="alert">
                         <l:icon class="icon-help icon-sm" alt="${%Access key format help}"/>
                         The access key must be in the <b><span>&lt;</span>server host name<span>&gt;</span>=<span>&lt;</span>access key<span>&gt;</span></b> format.
                         For more details please refer to the <a class="alert-link" href="https://docs.gradle.com/enterprise/gradle-plugin/#manual_access_key_configuration" target="_blank">documentation</a>.
                     </div>
-                    <f:password/>
+                    <c:select default="${instance.accessKeyCredentialId}"/>
                 </f:entry>
                 <f:entry title="${%Develocity short-lived access tokens expiry}" field="shortLivedTokenExpiry">
                     <f:textbox checkMethod="post"/>
@@ -75,11 +75,8 @@
                 <f:entry title="${%Gradle plugin repository url}" field="gradlePluginRepositoryUrl">
                     <f:textbox checkMethod="post"/>
                 </f:entry>
-                <f:entry title="${%Gradle plugin repository username}" field="gradlePluginRepositoryUsername">
-                    <f:textbox checkMethod="post"/>
-                </f:entry>
-                <f:entry title="${%Gradle plugin repository password}" field="gradlePluginRepositoryPassword">
-                    <f:password/>
+                <f:entry title="Gradle plugin repository credential ID" field="gradlePluginRepositoryCredentialId">
+                    <c:select default="${instance.gradlePluginRepositoryCredentialId}"/>
                 </f:entry>
                 <f:entry title="${%Gradle auto-injection enabled nodes}"
                          help="/plugin/gradle/help-gradleInjectionEnabledNodes.html">
@@ -112,6 +109,12 @@
                 </f:entry>
                 <f:entry title="${%Common Custom User Data Maven extension version}" field="ccudExtensionVersion">
                     <f:textbox checkMethod="post"/>
+                </f:entry>
+                <f:entry title="${%Maven extension repository url}" field="mavenExtensionRepositoryUrl">
+                    <f:textbox checkMethod="post"/>
+                </f:entry>
+                <f:entry title="Maven Extension repository credential ID" field="mavenExtensionRepositoryCredentialId">
+                    <c:select default="${instance.mavenExtensionRepositoryCredentialId}"/>
                 </f:entry>
                 <f:entry title="${%Develocity Maven Extension Custom Coordinates}" field="mavenExtensionCustomCoordinates">
                     <f:textbox checkMethod="post"/>

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-accessKeyCredentialId.html
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-accessKeyCredentialId.html
@@ -1,0 +1,3 @@
+<div>
+    The credentials containing Develocity access key.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-gradlePluginRepositoryCredentialId.html
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-gradlePluginRepositoryCredentialId.html
@@ -1,0 +1,3 @@
+<div>
+    The credentials containing username and password for a custom Gradle Plugin repository.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-mavenExtensionRepositoryCredentialId.html
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-mavenExtensionRepositoryCredentialId.html
@@ -1,0 +1,3 @@
+<div>
+    The credentials containing username and password for a custom Maven repository.
+</div>

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-mavenExtensionRepositoryUrl.html
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/help-mavenExtensionRepositoryUrl.html
@@ -1,0 +1,4 @@
+<div>
+    The URL of the repository to use when resolving the Develocity and Common Custom User Data extensions.
+    Defaults to the Maven Central.
+</div>

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
@@ -1,5 +1,8 @@
 package hudson.plugins.gradle.injection
 
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
 import hudson.EnvVars
 import hudson.model.ParameterValue
 import hudson.model.Run
@@ -8,6 +11,7 @@ import hudson.plugins.gradle.BaseJenkinsIntegrationTest
 import hudson.plugins.gradle.injection.BuildScanEnvironmentContributor.DevelocityParametersAction
 import hudson.plugins.gradle.injection.token.ShortLivedTokenClient
 import hudson.util.Secret
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
 import spock.lang.Subject
 
 class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
@@ -21,7 +25,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'does nothing if no access key'() {
         given:
         def config = InjectionConfig.get()
-        config.setAccessKey(Secret.fromString(""))
+        config.setAccessKeyCredentialId("")
         config.save()
 
         when:
@@ -34,7 +38,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'does nothing if no password'() {
         given:
         def config = InjectionConfig.get()
-        config.setGradlePluginRepositoryPassword(Secret.fromString(""))
+        config.setGradlePluginRepositoryCredentialId("")
         config.save()
 
         when:
@@ -47,45 +51,62 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'adds empty action if access key is invalid'() {
         given:
         def config = InjectionConfig.get()
-        config.setAccessKey(Secret.fromString("secret"))
+        def accessKeyCredentialId = UUID.randomUUID().toString()
+        config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
+
+        createStringCredentials(accessKeyCredentialId, "invalidSecret")
 
         when:
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { action ->
-            action.is(DevelocityParametersAction.empty())
+        // Each query for finding the credential by ID creates an action
+        2 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                action.is(DevelocityParametersAction.empty())
+            }
         }
     }
 
     def 'adds action if access key is invalid but password is there'() {
         given:
         def config = InjectionConfig.get()
-        config.setAccessKey(Secret.fromString("secret"))
-        config.setGradlePluginRepositoryPassword(Secret.fromString("foo"))
+        def accessKeyCredentialId = UUID.randomUUID().toString()
+        def repositoryPasswordCredentialId = UUID.randomUUID().toString()
+        config.setAccessKeyCredentialId(accessKeyCredentialId)
+        config.setGradlePluginRepositoryCredentialId(repositoryPasswordCredentialId)
         config.save()
+
+        createStringCredentials(accessKeyCredentialId, "invalidSecret")
+        createUsernamePasswordCredentials(repositoryPasswordCredentialId, "john", "foo")
 
         when:
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { DevelocityParametersAction action ->
-            def parameters = action.getAllParameters()
-            parameters.size() == 1
-            paramEquals(parameters.first(), 'GRADLE_PLUGIN_REPOSITORY_PASSWORD', 'foo')
+        // Each query for finding the credential by ID creates an action
+        3 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                def parameters = action.getAllParameters()
+                parameters.size() == 1
+                paramEquals(parameters.first(), 'GRADLE_PLUGIN_REPOSITORY_PASSWORD', 'foo')
+            }
         }
     }
 
     def 'adds an action with the short lived token from one single access key'() {
         given:
         def accessKey = "localhost=secret"
+        def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
         config.setServer('http://localhost')
-        config.setAccessKey(Secret.fromString(accessKey))
+        config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
-        def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
 
+        createStringCredentials(accessKeyCredentialId, accessKey)
+
+        def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
 
         shortLivedTokenClient.get(config.getServer(), key, null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
 
@@ -93,24 +114,30 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { DevelocityParametersAction action ->
-            def parameters = action.getAllParameters()
-            parameters.size() == 2
-            paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz')
-            paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
+        // Each query for finding the credential by ID creates an action
+        2 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                def parameters = action.getAllParameters()
+                parameters.size() == 2
+                paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz')
+                paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
+            }
         }
     }
 
     def 'adds an action with the short lived token with multiple keys and enforce url is true'() {
         given:
         def accessKey = "localhost=secret;other=secret2"
+        def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
         config.setServer('http://localhost')
         config.setEnforceUrl(true)
-        config.setAccessKey(Secret.fromString(accessKey))
+        config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
-        def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
 
+        createStringCredentials(accessKeyCredentialId, accessKey)
+
+        def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
 
         shortLivedTokenClient.get(config.getServer(), key, null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
 
@@ -118,22 +145,27 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { DevelocityParametersAction action ->
-            def parameters = action.getAllParameters()
-            parameters.size() == 2
-            paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz')
-            paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
+        2 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                def parameters = action.getAllParameters()
+                parameters.size() == 2
+                paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz')
+                paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
+            }
         }
     }
 
     def 'adds an action with the short lived token with multiple keys and enforce url is false'() {
         given:
         def accessKey = "localhost=secret;other=secret2"
+        def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
         config.setServer('http://localhost')
         config.setEnforceUrl(false)
-        config.setAccessKey(Secret.fromString(accessKey))
+        config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
+
+        createStringCredentials(accessKeyCredentialId, accessKey)
 
         shortLivedTokenClient.get("https://localhost", DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'secret'), null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
         shortLivedTokenClient.get("https://other", DevelocityAccessCredentials.HostnameAccessKey.of('other', 'secret2'), null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('other', 'abc'))
@@ -142,28 +174,35 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { DevelocityParametersAction action ->
-            def parameters = action.getAllParameters()
-            parameters.size() == 2
-            paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz;other=abc')
-            paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz;other=abc')
+        2 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                def parameters = action.getAllParameters()
+                parameters.size() == 2
+                paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz;other=abc')
+                paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz;other=abc')
+            }
         }
     }
 
     def 'adds an action with the password'() {
         given:
+        def passwordCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
-        config.setGradlePluginRepositoryPassword(Secret.fromString("foo"))
+        config.setGradlePluginRepositoryCredentialId(passwordCredentialId)
         config.save()
+
+        createUsernamePasswordCredentials(passwordCredentialId, "john", "foo")
 
         when:
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { DevelocityParametersAction action ->
-            def parameters = action.getAllParameters()
-            parameters.size() == 1
-            paramEquals(parameters.first(), 'GRADLE_PLUGIN_REPOSITORY_PASSWORD', 'foo')
+        2 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                def parameters = action.getAllParameters()
+                parameters.size() == 1
+                paramEquals(parameters.first(), 'GRADLE_PLUGIN_REPOSITORY_PASSWORD', 'foo')
+            }
         }
     }
 
@@ -172,29 +211,54 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         def config = InjectionConfig.get()
         config.setServer('http://localhost')
 
+        def accessKeyCredentialId = UUID.randomUUID().toString()
+        def repositoryPasswordCredentialId = UUID.randomUUID().toString()
         def accessKey = "localhost=secret"
-        config.setAccessKey(Secret.fromString(accessKey))
-        config.setGradlePluginRepositoryPassword(Secret.fromString("foo"))
+        config.setAccessKeyCredentialId(accessKeyCredentialId)
+        config.setGradlePluginRepositoryCredentialId(repositoryPasswordCredentialId)
         config.save()
+
+        createStringCredentials(accessKeyCredentialId, accessKey)
+        createUsernamePasswordCredentials(repositoryPasswordCredentialId, "john", "foo")
+
         def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
 
         shortLivedTokenClient.get(config.getServer(), key, null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
-
 
         when:
         buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
 
         then:
-        1 * run.addAction { DevelocityParametersAction action ->
-            def parameters = action.getAllParameters()
-            parameters.size() == 3
-            paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz')
-            paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
-            paramEquals(parameters[2], 'GRADLE_PLUGIN_REPOSITORY_PASSWORD', 'foo')
+        3 * run.addAction { action ->
+            if (action instanceof DevelocityParametersAction) {
+                def parameters = action.getAllParameters()
+                parameters.size() == 3
+                paramEquals(parameters[0], 'GRADLE_ENTERPRISE_ACCESS_KEY', 'localhost=xyz')
+                paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
+                paramEquals(parameters[2], 'GRADLE_PLUGIN_REPOSITORY_PASSWORD', 'foo')
+            }
         }
     }
 
-    private boolean paramEquals(ParameterValue param, String name, String value) {
+    private static createUsernamePasswordCredentials(String id, String username, String password) {
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.GLOBAL, id, "Username and Password credentials", username, password
+                ))
+
+        SystemCredentialsProvider.getInstance().save()
+    }
+
+    private static createStringCredentials(String id, String secret) {
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL, id, "String credentials", Secret.fromString(secret)
+                ))
+
+        SystemCredentialsProvider.getInstance().save()
+    }
+
+    private static boolean paramEquals(ParameterValue param, String name, String value) {
         param.name == name && param.value?.plainText == value
     }
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -1,5 +1,7 @@
 package hudson.plugins.gradle.injection
 
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider
 import hudson.EnvVars
 import hudson.Util
 import hudson.model.FreeStyleProject
@@ -15,6 +17,7 @@ import hudson.slaves.DumbSlave
 import hudson.slaves.EnvironmentVariablesNodeProperty
 import hudson.util.Secret
 import org.apache.commons.lang3.StringUtils
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jvnet.hudson.test.CreateFileBuilder
@@ -24,8 +27,6 @@ import spock.lang.Unroll
 
 @Unroll
 class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest {
-
-    private static final String CCUD_PLUGIN_VERSION = '1.12.1'
 
     private static final String MSG_INIT_SCRIPT_APPLIED = "Connection to Develocity: http://foo.com"
 
@@ -614,10 +615,19 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         when:
         enableBuildInjection(agent, gradleVersion)
+        def credentialId = UUID.randomUUID().toString()
         withInjectionConfig {
             server = mockDevelocity.address.toString()
-            accessKey = Secret.fromString("localhost=secret")
+            accessKeyCredentialId = credentialId
         }
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL,
+                        credentialId,
+                        "Develocity Access Key",
+                        Secret.fromString("localhost=secret")
+                ))
+        SystemCredentialsProvider.getInstance().save()
         def secondRun = j.buildAndAssertSuccess(project)
 
         then:
@@ -653,9 +663,18 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         when:
         enableBuildInjection(agent, gradleVersion)
+        def credentialId =UUID.randomUUID().toString()
         withInjectionConfig {
-            accessKey = Secret.fromString("secret")
+            accessKeyCredentialId = credentialId
         }
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL,
+                        credentialId,
+                        "Develocity Access Key",
+                        Secret.fromString("secret")
+                ))
+        SystemCredentialsProvider.getInstance().save()
         def secondRun = j.buildAndAssertSuccess(project)
 
         then:

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
@@ -43,13 +43,13 @@ class MavenExtensionsHandlerTest extends Specification {
         def root = new FilePath(folder)
 
         when:
-        def firstFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.DEVELOCITY, "1.22", root)
+        def firstFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.DEVELOCITY, "1.22", root, null, null)
 
         then:
         firstFilePath.exists()
 
         when:
-        def secondFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.CCUD, "2.0", root)
+        def secondFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.CCUD, "2.0", root, null, null)
 
         then:
         secondFilePath.exists()
@@ -61,8 +61,8 @@ class MavenExtensionsHandlerTest extends Specification {
         def root = new FilePath(folder)
 
         when:
-        def geExtensionFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.DEVELOCITY, "1.22", root)
-        def ccudExtensionFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.CCUD, "2.0", root)
+        def geExtensionFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.DEVELOCITY, "1.22", root, null, null)
+        def ccudExtensionFilePath = mavenExtensionsHandler.downloadExtensionToAgent(MavenExtension.CCUD, "2.0", root, null, null)
 
         then:
         geExtensionFilePath.exists()
@@ -77,4 +77,5 @@ class MavenExtensionsHandlerTest extends Specification {
         !geExtensionFilePath.exists()
         !ccudExtensionFilePath.exists()
     }
+
 }


### PR DESCRIPTION
This PR migrates the usage of Jenkins Secrets to the Credentials Plugin. 
Once users upgrade, existing secrets will be automatically migrated to credentials.

Additionally, this PR adds the ability to configure a custom Maven repository URL for download of extensions. It is also possible to specify a username and password for basic authentication for that repository.

<img width="1407" alt="Screenshot 2024-09-05 at 22 21 37" src="https://github.com/user-attachments/assets/b0d35998-bb1d-4a53-8ffc-0aef8b4f1c18">
<img width="1409" alt="Screenshot 2024-09-05 at 22 21 50" src="https://github.com/user-attachments/assets/7610157c-8363-4c68-9f5d-192d42bb2bf9">
<img width="1418" alt="Screenshot 2024-09-05 at 22 22 02" src="https://github.com/user-attachments/assets/3fb41e96-7859-45fc-87c7-ae93cdb67965">
