### PR TITLE
Save the configuration after migration is done

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
+++ b/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
@@ -648,6 +648,8 @@ public class InjectionConfig extends GlobalConfiguration {
 
             setAccessKeyCredentialId(stringCredentials.getId());
             accessKey = null;
+
+            save();
         }
         if (gradlePluginRepositoryUsername != null && gradlePluginRepositoryPassword != null && gradlePluginRepositoryCredentialId == null) {
             StandardUsernamePasswordCredentials standardUsernameCredentials = new UsernamePasswordCredentialsImpl(
@@ -664,7 +666,10 @@ public class InjectionConfig extends GlobalConfiguration {
             setGradlePluginRepositoryCredentialId(standardUsernameCredentials.getId());
             gradlePluginRepositoryUsername = null;
             gradlePluginRepositoryPassword = null;
+
+            save();
         }
+
         return this;
     }
 


### PR DESCRIPTION
Once migration is finished, we need to persist the data such that it's not done again