### PR TITLE
Fix Gradle daemon cleanup on Windows

### DIFF
--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -72,7 +72,7 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
         if(Functions.isWindows()) {
             try {
                 println 'Killing Gradle processes'
-                def proc = '''WMIC PROCESS where "Name like 'java%%' AND CommandLine like '%%GradleDaemon%%'" Call Terminate"'''.execute()
+                def proc = '''WMIC PROCESS where "Name like 'java%%' AND CommandLine like '%%hudson.plugins.gradle.GradleInstallation%%'" Call Terminate"'''.execute()
                 proc.waitFor(30, TimeUnit.SECONDS)
                 println "output: ${proc.text}"
                 println "code: ${proc.exitValue()}"

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -69,7 +69,7 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
 
     @SuppressWarnings("CatchException")
     def cleanup() {
-        if(Functions.isWindows()) {
+        if(Functions.isWindows() && gradleInstallationRule.gradleVersion != '8.10.1') {
             try {
                 println 'Killing Gradle processes'
                 def proc = '''WMIC PROCESS where "Name like 'java%%' AND CommandLine like '%%hudson.plugins.gradle.GradleInstallation%%'" Call Terminate"'''.execute()

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -69,10 +69,10 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
 
     @SuppressWarnings("CatchException")
     def cleanup() {
-        if(Functions.isWindows() && gradleInstallationRule.gradleVersion != '8.10.1') {
+        if(Functions.isWindows()) {
             try {
                 println 'Killing Gradle processes'
-                def proc = '''WMIC PROCESS where "Name like 'java%%' AND CommandLine like '%%hudson.plugins.gradle.GradleInstallation%%'" Call Terminate"'''.execute()
+                def proc = '''WMIC PROCESS where "Name like 'java%' AND CommandLine like '%hudson.plugins.gradle.GradleInstallation%'" Call Terminate"'''.execute()
                 proc.waitFor(30, TimeUnit.SECONDS)
                 println "output: ${proc.text}"
                 println "code: ${proc.exitValue()}"

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -30,7 +30,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     private static final String MSG_INIT_SCRIPT_APPLIED = "Connection to Develocity: http://foo.com"
 
-    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.4', '8.6']
+    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.4', '8.10.1']
 
     private static final EnvVars EMPTY_ENV = new EnvVars()
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -30,7 +30,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     private static final String MSG_INIT_SCRIPT_APPLIED = "Connection to Develocity: http://foo.com"
 
-    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.4', '8.10.1']
+    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.4', '8.9']
 
     private static final EnvVars EMPTY_ENV = new EnvVars()
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The Gradle daemon of the build process was killed when using Gradle 8.10.1.
This fix is supposed to kill only Gradle daemon processes spawned during Jenkins builds.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
