### PR TITLE
Fix failure with configuration-as-code plugin when upgrading

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
     testImplementation("org.jenkins-ci.main:jenkins-test-harness:2225.v04fa_3929c9b_5")
     testImplementation("org.jenkins-ci.main:jenkins-test-harness-tools:2.2")
     testImplementation("io.jenkins:configuration-as-code:1.4")
+    testImplementation("io.jenkins.configuration-as-code:test-harness:1.4")
     testImplementation("org.jenkins-ci.plugins:timestamper")
     testImplementation("org.jenkins-ci.plugins:pipeline-stage-step")
     testImplementation("org.jenkins-ci.plugins:pipeline-maven:3.10.0")

--- a/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
+++ b/src/main/java/hudson/plugins/gradle/injection/InjectionConfig.java
@@ -102,6 +102,9 @@ public class InjectionConfig extends GlobalConfiguration {
     // Legacy property that is not used anymore
     private transient String injectionVcsRepositoryPatterns;
     private VcsRepositoryFilter parsedVcsRepositoryFilter = VcsRepositoryFilter.EMPTY;
+    // Legacy properties, kept for reading old configurations
+    private transient boolean injectMavenExtension;
+    private transient boolean injectCcudExtension;
 
     public InjectionConfig() {
         load();
@@ -365,6 +368,24 @@ public class InjectionConfig extends GlobalConfiguration {
     @DataBoundSetter
     public void setCheckForBuildAgentErrors(boolean checkForBuildAgentErrors) {
         this.checkForBuildAgentErrors = checkForBuildAgentErrors;
+    }
+
+    public boolean isInjectCcudExtension() {
+        return injectCcudExtension;
+    }
+
+    @DataBoundSetter
+    public void setInjectCcudExtension(boolean injectCcudExtension) {
+        this.injectCcudExtension = injectCcudExtension;
+    }
+
+    public boolean isInjectMavenExtension() {
+        return injectMavenExtension;
+    }
+
+    @DataBoundSetter
+    public void setInjectMavenExtension(boolean injectMavenExtension) {
+        this.injectMavenExtension = injectMavenExtension;
     }
 
     /**

--- a/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigWithCasCTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigWithCasCTest.groovy
@@ -1,0 +1,47 @@
+package hudson.plugins.gradle.injection
+
+
+import hudson.plugins.gradle.AbstractIntegrationTest
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule
+import org.junit.Rule
+import org.junit.rules.RuleChain
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Unroll
+@Subject(InjectionConfig.class)
+class InjectionConfigWithCasCTest extends AbstractIntegrationTest {
+    @Rule
+    public final RuleChain rules = RuleChain.outerRule(noSpaceInTmpDirs).around(new JenkinsConfiguredWithCodeRule())
+
+    @ConfiguredWithCode("injection-config.yml")
+    def 'current configuration is readable with JCasC'() {
+        expect:
+        with(InjectionConfig.get()) {
+            it.allowUntrusted == true
+            it.ccudExtensionCustomCoordinates == "mycustom-ccud:ext"
+            it.ccudExtensionVersion == "2.0.1"
+            it.ccudPluginVersion == "2.0.2"
+            it.checkForBuildAgentErrors == true
+            it.enabled == true
+            it.enforceUrl == true
+            it.gradleCaptureTaskInputFiles == true
+            it.gradleInjectionDisabledNodes*.label == ["non-gradle-node"]
+            it.gradleInjectionEnabledNodes*.label == ["gradle-node"]
+            it.gradlePluginRepositoryUrl == "https://plugins.gradle.org"
+            it.gradlePluginVersion == "3.18.1"
+            it.injectMavenExtension == true
+            it.injectCcudExtension == true
+            it.mavenCaptureGoalInputFiles == true
+            it.mavenExtensionCustomCoordinates == "mycustom:ext"
+            it.mavenExtensionRepositoryUrl == "https://repo1.maven.org/maven2"
+            it.mavenExtensionVersion == "1.22.1"
+            it.mavenInjectionDisabledNodes*.label == ["non-maven-node"]
+            it.mavenInjectionEnabledNodes*.label == ["maven-node"]
+            it.server == "http://localhost:5086"
+            it.shortLivedTokenExpiry == 24
+            it.vcsRepositoryFilter == "+:myrepo"
+        }
+    }
+}

--- a/src/test/resources/injection-config.yml
+++ b/src/test/resources/injection-config.yml
@@ -1,0 +1,30 @@
+jenkins:
+unclassified:
+    injectionConfig:
+        allowUntrusted: true
+        ccudExtensionCustomCoordinates: "mycustom-ccud:ext"
+        ccudExtensionVersion: "2.0.1"
+        ccudPluginVersion: "2.0.2"
+        checkForBuildAgentErrors: true
+        enabled: true
+        enforceUrl: true
+        gradleCaptureTaskInputFiles: true
+        gradleInjectionDisabledNodes:
+            -   label: "non-gradle-node"
+        gradleInjectionEnabledNodes:
+            -   label: "gradle-node"
+        gradlePluginRepositoryUrl: "https://plugins.gradle.org"
+        gradlePluginVersion: "3.18.1"
+        injectMavenExtension: true
+        injectCcudExtension: true
+        mavenCaptureGoalInputFiles: true
+        mavenExtensionCustomCoordinates: "mycustom:ext"
+        mavenExtensionRepositoryUrl: "https://repo1.maven.org/maven2"
+        mavenExtensionVersion: "1.22.1"
+        mavenInjectionDisabledNodes:
+            -   label: "non-maven-node"
+        mavenInjectionEnabledNodes:
+            -   label: "maven-node"
+        server: "http://localhost:5086"
+        shortLivedTokenExpiry: 24
+        vcsRepositoryFilter: "+:myrepo"


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-73843

`injectMavenExtension` and `injectCcudExtension` have been removed in 2.13. It causes a warning in Jenkins admin UI after upgrading, it causes a hard failure if using the Jenkins configuration-as-code plugin with a yaml configuration referencing those removed attributes.

This PR just keeps those attributes as transient, till the end of times I guess.

### Testing done
- Integration test
- Manually tested the upgrade with a pre-configured JCasC YAML referencing `injectMavenExtension` and `injectCcudExtension`.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
