### PR TITLE
Fix Acceptance tests

### DIFF
--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
     add(gradlePlugin.name, project(path = ":", configuration = "gradlePluginJpi"))
 }
 
-val currentJava = JavaVersion.current()
-
 val jenkinsVersions = listOf(
     JenkinsVersion.LATEST,
     JenkinsVersion.LATEST_LTS,
@@ -49,9 +47,6 @@ val jenkinsVersions = listOf(
 )
 
 jenkinsVersions
-    .filter { jenkinsVersion ->
-        jenkinsVersion.isDefault || currentJava.isCompatibleWith(jenkinsVersion.requiredJavaVersion)
-    }
     .forEach { jenkinsVersion ->
         val downloadJenkinsTask =
             tasks.register<Download>("downloadJenkins${jenkinsVersion.label}") {
@@ -154,7 +149,4 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL, val javaVer
         } else {
             version.split("-").joinToString(separator = "") { it.capitalized() }
         }
-
-    val requiredJavaVersion: JavaVersion
-        get() = JavaVersion.toVersion(javaVersion.toString())
 }

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -10,6 +10,14 @@ plugins {
 
 val ciJenkinsBuild: Boolean by (gradle as ExtensionAware).extra
 
+java {
+    // Only used for compilation. We don't rely on toolchain for running the tests,
+    // as Jenkins ATH doesn't allow to specify the JAVA_HOME.
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 group = "org.jenkins-ci.plugins"
 description = "Acceptance tests of Gradle plugin"
 

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     // same version as used by ATH
     annotationProcessor("org.jenkins-ci:annotation-indexer:1.12")
 
-    implementation("org.jenkins-ci:acceptance-test-harness:5740.vd30f30408987")
+    implementation("org.jenkins-ci:acceptance-test-harness:5770.v81b_784f28b_d7")
 
     testImplementation(platform("io.netty:netty-bom:4.1.114.Final"))
     testImplementation("io.ratpack:ratpack-test:2.0.0-rc-1")

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -12,7 +12,7 @@ val ciJenkinsBuild: Boolean by (gradle as ExtensionAware).extra
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     // same version as used by ATH
     annotationProcessor("org.jenkins-ci:annotation-indexer:1.12")
 
-    implementation("org.jenkins-ci:acceptance-test-harness:5770.v81b_784f28b_d7")
+    implementation("org.jenkins-ci:acceptance-test-harness:5740.vd30f30408987")
 
     testImplementation(platform("io.netty:netty-bom:4.1.114.Final"))
     testImplementation("io.ratpack:ratpack-test:2.0.0-rc-1")

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -12,7 +12,7 @@ val ciJenkinsBuild: Boolean by (gradle as ExtensionAware).extra
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 
@@ -79,6 +79,10 @@ jenkinsVersions
                 // Do not run on Windows as written here: https://github.com/jenkinsci/acceptance-test-harness/blob/master/docs/EXTERNAL.md
                 !ciJenkinsBuild && !OperatingSystem.current().isWindows
             }
+
+            environment("JAVA_HOME", javaToolchains.launcherFor {
+                languageVersion.set(jenkinsVersion.javaVersion)
+            }.get().executablePath.toString())
 
             javaLauncher.set(javaToolchains.launcherFor {
                 languageVersion.set(jenkinsVersion.javaVersion)

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 val jenkinsVersions = listOf(
     JenkinsVersion.LATEST,
     JenkinsVersion.LATEST_LTS,
-    JenkinsVersion.V2_401
+    JenkinsVersion.V2_440
 )
 
 jenkinsVersions
@@ -106,7 +106,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL) {
 
         private const val LATEST_VERSION = "latest"
         private const val LATEST_LTS_VERSION = "latest-lts"
-        private const val V2_401_VERSION = "2.401.3"
+        private const val V2_440_VERSION = "2.440.3"
 
         private const val MIRROR = "https://updates.jenkins.io"
 
@@ -114,7 +114,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL) {
 
         val LATEST = of(LATEST_VERSION)
         val LATEST_LTS = of(LATEST_LTS_VERSION)
-        val V2_401 = of(V2_401_VERSION)
+        val V2_440 = of(V2_440_VERSION)
 
         private fun of(version: String): JenkinsVersion {
             val downloadUrl =
@@ -136,7 +136,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL) {
     }
 
     val isDefault: Boolean
-        get() = version == V2_401_VERSION
+        get() = version == V2_440_VERSION
 
     val label: String
         get() = if (isJenkinsVersion(version)) {

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -10,14 +10,6 @@ plugins {
 
 val ciJenkinsBuild: Boolean by (gradle as ExtensionAware).extra
 
-java {
-    // Only used for compilation. We don't rely on toolchain for running the tests,
-    // as Jenkins ATH doesn't allow to specify the JAVA_HOME.
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-}
-
 group = "org.jenkins-ci.plugins"
 description = "Acceptance tests of Gradle plugin"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,9 +16,9 @@ plugins {
 group = "org.jenkins-ci.plugins"
 description = "This plugin adds Gradle support to Jenkins"
 
-val coreBaseVersion = "2.401"
+val coreBaseVersion = "2.440"
 val corePatchVersion = "3"
-val coreBomVersion = "2745.vc7b_fe4c876fa_"
+val coreBomVersion = "3387.v0f2773fa_3200"
 
 val gradleExt = (gradle as ExtensionAware).extra
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ jenkinsPlugin {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 
     registerFeature("optionalPlugin") {
@@ -91,9 +91,6 @@ val includedLibs: Configuration by configurations.creating
 val gradlePluginJpi: Configuration by configurations.creating { isCanBeConsumed = true; isCanBeResolved = false }
 
 dependencies {
-    "codenarc"("org.codehaus.groovy:groovy-all:3.0.21")
-    "codenarc"("org.codenarc:CodeNarc:1.6.1")
-
     api(platform("io.jenkins.tools.bom:bom-${coreBaseVersion}.x:${coreBomVersion}"))
 
     implementation("org.jenkins-ci.plugins:jackson2-api")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ jenkinsPlugin {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 
     registerFeature("optionalPlugin") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,9 @@ val includedLibs: Configuration by configurations.creating
 val gradlePluginJpi: Configuration by configurations.creating { isCanBeConsumed = true; isCanBeResolved = false }
 
 dependencies {
+    "codenarc"("org.codehaus.groovy:groovy-all:3.0.21")
+    "codenarc"("org.codenarc:CodeNarc:1.6.1")
+
     api(platform("io.jenkins.tools.bom:bom-${coreBaseVersion}.x:${coreBomVersion}"))
 
     implementation("org.jenkins-ci.plugins:jackson2-api")

--- a/src/test/groovy/hudson/plugins/gradle/BuildScanIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BuildScanIntegrationTest.groovy
@@ -91,13 +91,14 @@ class BuildScanIntegrationTest extends BaseGradleIntegrationTest {
 
     def 'detects build scan in pipeline log'() {
         given:
+        gradleInstallationRule.gradleVersion = '7.3.3'
         gradleInstallationRule.addInstallation()
         def pipelineJob = j.createProject(WorkflowJob)
         pipelineJob.setDefinition(new CpsFlowDefinition("""
 node {
    stage('Build') {
       // Run the maven build
-      def gradleHome = tool name: '7.3.3', type: 'gradle'
+      def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
       writeFile file: 'settings.gradle', text: ''
       writeFile file: 'build.gradle', text: "buildScan { termsOfServiceUrl = 'https://gradle.com/terms-of-service'; termsOfServiceAgree = 'yes' }"
       if (isUnix()) {

--- a/src/test/groovy/hudson/plugins/gradle/BuildScanIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BuildScanIntegrationTest.groovy
@@ -97,7 +97,7 @@ class BuildScanIntegrationTest extends BaseGradleIntegrationTest {
 node {
    stage('Build') {
       // Run the maven build
-      def gradleHome = tool name: '5.5', type: 'gradle'
+      def gradleHome = tool name: '7.3.3', type: 'gradle'
       writeFile file: 'settings.gradle', text: ''
       writeFile file: 'build.gradle', text: "buildScan { termsOfServiceUrl = 'https://gradle.com/terms-of-service'; termsOfServiceAgree = 'yes' }"
       if (isUnix()) {
@@ -125,7 +125,7 @@ node {
 
     def 'detects build scan in pipeline log using withGradle'() {
         given:
-        gradleInstallationRule.gradleVersion = '5.6.4'
+        gradleInstallationRule.gradleVersion = '7.3.3'
         gradleInstallationRule.addInstallation()
         def pipelineJob = j.createProject(WorkflowJob)
         pipelineJob.setDefinition(new CpsFlowDefinition("""
@@ -174,7 +174,7 @@ node {
 
     def 'does not find build scans in pipeline logs when none have been published'() {
         given:
-        gradleInstallationRule.gradleVersion = '5.6.4'
+        gradleInstallationRule.gradleVersion = '7.3.3'
         gradleInstallationRule.addInstallation()
         def pipelineJob = j.createProject(WorkflowJob)
         pipelineJob.setDefinition(new CpsFlowDefinition("""
@@ -206,7 +206,7 @@ node {
 
     def 'does not find build scans in pipeline logs when none have been published with withGradle'() {
         given:
-        gradleInstallationRule.gradleVersion = '5.6.4'
+        gradleInstallationRule.gradleVersion = '7.3.3'
         gradleInstallationRule.addInstallation()
         def pipelineJob = j.createProject(WorkflowJob)
         pipelineJob.setDefinition(new CpsFlowDefinition("""

--- a/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -16,7 +16,7 @@ class GradleInstallationRule extends TestWatcher {
     String gradleVersion
     private final JenkinsRule j
 
-    GradleInstallationRule(String gradleVersion = '7.3.3', JenkinsRule j) {
+    GradleInstallationRule(String gradleVersion = '5.5', JenkinsRule j) {
         this.gradleVersion = gradleVersion
         this.j = j
     }

--- a/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -16,7 +16,7 @@ class GradleInstallationRule extends TestWatcher {
     String gradleVersion
     private final JenkinsRule j
 
-    GradleInstallationRule(String gradleVersion = '5.5', JenkinsRule j) {
+    GradleInstallationRule(String gradleVersion = '7.3.3', JenkinsRule j) {
         this.gradleVersion = gradleVersion
         this.j = j
     }

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -30,7 +30,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     private static final String MSG_INIT_SCRIPT_APPLIED = "Connection to Develocity: http://foo.com"
 
-    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '5.6.4', '6.9.4', '7.6.4', '8.9']
+    private static final List<String> GRADLE_VERSIONS = ['4.10.3', '6.9.4', '7.6.4', '8.9']
 
     private static final EnvVars EMPTY_ENV = new EnvVars()
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/DevelocityExceptionLogProcessorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/DevelocityExceptionLogProcessorTest.groovy
@@ -2,13 +2,13 @@ package hudson.plugins.gradle.injection
 
 import hudson.console.ConsoleNote
 import hudson.model.Actionable
+import hudson.plugins.gradle.BaseJenkinsIntegrationTest
 import hudson.plugins.gradle.BuildScanAction
-import spock.lang.Specification
 import spock.lang.Subject
 
 import java.nio.charset.StandardCharsets
 
-class DevelocityExceptionLogProcessorTest extends Specification {
+class DevelocityExceptionLogProcessorTest extends BaseJenkinsIntegrationTest {
 
     private static final String GRADLE_PLUGIN_ERROR = "Internal error in Gradle Enterprise Gradle plugin: com.acme.FooBar"
     private static final String MAVEN_EXTENSION_ERROR = "[ERROR] Internal error in Gradle Enterprise Maven extension: com.acme.FooBar"

--- a/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigTest.groovy
@@ -334,7 +334,8 @@ class InjectionConfigTest extends BaseJenkinsIntegrationTest {
     }
 
     private static HtmlButton getAddButton(HtmlForm form, String label) {
-        def xpath = "//div[text() = '$label']/following-sibling::div[contains(@class, 'setting-main')]//span[contains(@class, 'repeatable-add')]//button[text() = 'Add']"
+        def xpath = "//div[text() = '$label']/following-sibling::div[contains(@class, 'setting-main')]//button[contains(@class, 'repeatable-add')]"
+
         return form.getFirstByXPath(xpath)
     }
 }

--- a/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsDetectorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsDetectorTest.groovy
@@ -30,7 +30,7 @@ class MavenExtensionsDetectorTest extends Specification {
         dir {
             '.mvn' {
                 'extensions.xml'(generateExtensionsXml(
-                    *(extensions.collect({ MavenCoordinates.parseCoordinates(it) }))))
+                        *(extensions.collect { MavenCoordinates.parseCoordinates(it) })))
             }
         }
 
@@ -68,9 +68,9 @@ class MavenExtensionsDetectorTest extends Specification {
         dir {
             '.mvn' {
                 'extensions.xml'(
-                    generateExtensionsXml(
-                        MavenCoordinates.parseCoordinates('my:ext:1.0'),
-                        MavenCoordinates.parseCoordinates('my:ext-ccud:1.0')))
+                        generateExtensionsXml(
+                                MavenCoordinates.parseCoordinates('my:ext:1.0'),
+                                MavenCoordinates.parseCoordinates('my:ext-ccud:1.0')))
             }
         }
 


### PR DESCRIPTION
This PR addresses several things:
1. Acceptance tests on CI are fixed by bumping the base Jenkins version to 2.440.3
2. Running Acceptance tests with Latest Jenkins version is fixed (instead of running only with Latest LTS)
3. Adjusting other tests accordingly after bump to 2.440.3