### PR TITLE
Do not set password parameters if DV injection is disabled

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -43,6 +43,10 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
 
     @Override
     public void buildEnvironmentFor(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
+        if (InjectionConfig.get().isDisabled() || alreadyExecuted(run)) {
+            return;
+        }
+
         String accessKeyCredentialId = InjectionConfig.get().getAccessKeyCredentialId();
         String gradlePluginRepositoryCredentialId = InjectionConfig.get().getGradlePluginRepositoryCredentialId();
 
@@ -55,7 +59,7 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
                 .map(StandardUsernamePasswordCredentials::getPassword)
                 .orElse(null);
 
-        if ((secretKey == null && secretPassword == null) || alreadyExecuted(run)) {
+        if (secretKey == null && secretPassword == null) {
             return;
         }
         DevelocityLogger logger = new DevelocityLogger(listener);

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
@@ -25,6 +25,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'does nothing if no access key'() {
         given:
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         config.setAccessKeyCredentialId("")
         config.save()
 
@@ -38,7 +39,21 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'does nothing if no password'() {
         given:
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         config.setGradlePluginRepositoryCredentialId("")
+        config.save()
+
+        when:
+        buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
+
+        then:
+        0 * run.addAction(_)
+    }
+
+    def 'does nothing if Develocity injection is disabled'() {
+        given:
+        def config = InjectionConfig.get()
+        config.setEnabled(false)
         config.save()
 
         when:
@@ -51,6 +66,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'adds empty action if access key is invalid'() {
         given:
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         def accessKeyCredentialId = UUID.randomUUID().toString()
         config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
@@ -72,6 +88,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
     def 'adds action if access key is invalid but password is there'() {
         given:
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         def accessKeyCredentialId = UUID.randomUUID().toString()
         def repositoryPasswordCredentialId = UUID.randomUUID().toString()
         config.setAccessKeyCredentialId(accessKeyCredentialId)
@@ -100,6 +117,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         def accessKey = "localhost=secret"
         def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         config.setServer('http://localhost')
         config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
@@ -130,6 +148,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         def accessKey = "localhost=secret;other=secret2"
         def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         config.setServer('http://localhost')
         config.setEnforceUrl(true)
         config.setAccessKeyCredentialId(accessKeyCredentialId)
@@ -160,6 +179,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         def accessKey = "localhost=secret;other=secret2"
         def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         config.setServer('http://localhost')
         config.setEnforceUrl(false)
         config.setAccessKeyCredentialId(accessKeyCredentialId)
@@ -188,6 +208,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         given:
         def passwordCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
+        config.setEnabled(true)
         config.setGradlePluginRepositoryCredentialId(passwordCredentialId)
         config.save()
 
@@ -214,6 +235,7 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         def accessKeyCredentialId = UUID.randomUUID().toString()
         def repositoryPasswordCredentialId = UUID.randomUUID().toString()
         def accessKey = "localhost=secret"
+        config.setEnabled(true)
         config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.setGradlePluginRepositoryCredentialId(repositoryPasswordCredentialId)
         config.save()


### PR DESCRIPTION
If Develocity injection is disabled, we don't want to have builds set with irrelevant password parameters.

### Testing done
- Unit test
- Manually tested that it works fine

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
