### PR TITLE
Do not configure old DV plugin version in tests

### DIFF
--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -49,8 +49,8 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
 
         withInjectionConfig {
             enabled = true
-            gradlePluginVersion = gradleVersion < '5.0' ? "1.16" : DEVELOCITY_PLUGIN_VERSION
-            ccudPluginVersion = gradlePluginVersion == '1.6' ? '1.13' : CCUD_PLUGIN_VERSION
+            gradlePluginVersion = DEVELOCITY_PLUGIN_VERSION
+            ccudPluginVersion = CCUD_PLUGIN_VERSION
             gradlePluginRepositoryUrl = repositoryAddress?.toString()
             gradleCaptureTaskInputFiles = captureTaskInputFiles
         }


### PR DESCRIPTION
The init script takes care of adapting the plugin version to old Gradle version.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
