### PR TITLE
Require 2.479.x or newer and migrate from EE 8 to EE 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPluginWithGradle(jdkVersions: ['11'], timeout: 180)
+buildPluginWithGradle(jdkVersions: ['17'], timeout: 180)

--- a/acceptance-tests/build.gradle.kts
+++ b/acceptance-tests/build.gradle.kts
@@ -14,7 +14,7 @@ java {
     // Only used for compilation. We don't rely on toolchain for running the tests,
     // as Jenkins ATH doesn't allow to specify the JAVA_HOME.
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 
@@ -32,9 +32,9 @@ val gradlePlugin: Configuration by configurations.creating { isCanBeConsumed = f
 
 dependencies {
     // same version as used by ATH
-    annotationProcessor("org.jenkins-ci:annotation-indexer:1.12")
+    annotationProcessor("org.jenkins-ci:annotation-indexer:1.18")
 
-    implementation("org.jenkins-ci:acceptance-test-harness:5740.vd30f30408987")
+    implementation("org.jenkins-ci:acceptance-test-harness:6133.v358d9a_47674f")
 
     testImplementation(platform("io.netty:netty-bom:4.1.118.Final"))
     testImplementation("io.ratpack:ratpack-test:2.0.0-rc-1")
@@ -45,7 +45,7 @@ dependencies {
 val jenkinsVersions = listOf(
     JenkinsVersion.LATEST,
     JenkinsVersion.LATEST_LTS,
-    JenkinsVersion.V2_440
+    JenkinsVersion.V2_479
 )
 
 jenkinsVersions
@@ -106,7 +106,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL) {
 
         private const val LATEST_VERSION = "latest"
         private const val LATEST_LTS_VERSION = "latest-lts"
-        private const val V2_440_VERSION = "2.440.3"
+        private const val V2_479_VERSION = "2.479.3"
 
         private const val MIRROR = "https://updates.jenkins.io"
 
@@ -114,7 +114,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL) {
 
         val LATEST = of(LATEST_VERSION)
         val LATEST_LTS = of(LATEST_LTS_VERSION)
-        val V2_440 = of(V2_440_VERSION)
+        val V2_479 = of(V2_479_VERSION)
 
         private fun of(version: String): JenkinsVersion {
             val downloadUrl =
@@ -136,7 +136,7 @@ data class JenkinsVersion(val version: String, val downloadUrl: URL) {
     }
 
     val isDefault: Boolean
-        get() = version == V2_440_VERSION
+        get() = version == V2_479_VERSION
 
     val label: String
         get() = if (isJenkinsVersion(version)) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jenkinsci.gradle.plugins.manifest.GenerateJenkinsManifestTask
 import java.util.zip.ZipFile
 
 plugins {
-    id("org.jenkins-ci.jpi") version "0.52.0"
+    id("org.jenkins-ci.jpi") version "0.53.1"
     id("com.github.spotbugs") version "6.1.5"
     id("codenarc")
     id("buildlogic.reproducible-archives")
@@ -16,9 +16,9 @@ plugins {
 group = "org.jenkins-ci.plugins"
 description = "This plugin adds Gradle support to Jenkins"
 
-val coreBaseVersion = "2.440"
+val coreBaseVersion = "2.479"
 val corePatchVersion = "3"
-val coreBomVersion = "3387.v0f2773fa_3200"
+val coreBomVersion = "3893.v213a_42768d35"
 
 val gradleExt = (gradle as ExtensionAware).extra
 
@@ -68,7 +68,7 @@ jenkinsPlugin {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 
     registerFeature("optionalPlugin") {
@@ -77,7 +77,7 @@ java {
 }
 
 tasks.compileJava {
-    options.release = 11
+    options.release = 17
 }
 
 // see https://github.com/jenkinsci/gradle-jpi-plugin#customizing-further
@@ -111,10 +111,7 @@ dependencies {
         exclude(group = "com.google.inject", module = "guice")
     }
 
-    // Higher versions fail in our tests with ClassNotFoundException during SCM initialization unless Jenkins is updated
-    "optionalPluginImplementation"("org.jenkins-ci.plugins:git:4.9.4") {
-        because("VCS repositories filtering is supported for Develocity auto-injection")
-    }
+    "optionalPluginImplementation"("org.jenkins-ci.plugins:git:5.7.0")
 
     implementation("commons-validator:commons-validator:1.9.0") {
         exclude(group = "commons-beanutils", module = "commons-beanutils")
@@ -123,13 +120,13 @@ dependencies {
 
     add(includedLibs.name, project(path = ":configuration-maven-extension", configuration = "mvnExtension"))
 
-    testImplementation("org.jenkins-ci.main:jenkins-test-harness:2225.v04fa_3929c9b_5")
+    testImplementation("org.jenkins-ci.main:jenkins-test-harness:2395.v8256a_2157798")
     testImplementation("org.jenkins-ci.main:jenkins-test-harness-tools:2.2")
-    testImplementation("io.jenkins:configuration-as-code:1.4")
-    testImplementation("io.jenkins.configuration-as-code:test-harness:1.4")
+    testImplementation("io.jenkins:configuration-as-code")
+    testImplementation("io.jenkins.configuration-as-code:test-harness")
     testImplementation("org.jenkins-ci.plugins:timestamper")
     testImplementation("org.jenkins-ci.plugins:pipeline-stage-step")
-    testImplementation("org.jenkins-ci.plugins:pipeline-maven:3.10.0")
+    testImplementation("org.jenkins-ci.plugins:pipeline-maven")
     testImplementation("org.spockframework:spock-core:2.3-groovy-2.5")
     testImplementation("org.spockframework:spock-junit4:2.3-groovy-2.5")
     testImplementation("net.bytebuddy:byte-buddy:1.17.1")
@@ -180,7 +177,7 @@ val main: SourceSet by sourceSets.getting
 val test: SourceSet by sourceSets.getting
 
 codenarc {
-    toolVersion = "1.5"
+    toolVersion = "1.6"
     sourceSets = listOf(test)
 }
 

--- a/src/main/java/hudson/plugins/gradle/enriched/EnrichedSummaryConfig.java
+++ b/src/main/java/hudson/plugins/gradle/enriched/EnrichedSummaryConfig.java
@@ -11,7 +11,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
 
 @Extension
@@ -96,7 +96,7 @@ public class EnrichedSummaryConfig extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) {
+    public boolean configure(StaplerRequest2 req, JSONObject json) {
         req.bindJSON(this, json);
         save();
         return true;

--- a/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/BaseGradleIntegrationTest.groovy
@@ -67,8 +67,9 @@ abstract class BaseGradleIntegrationTest extends AbstractIntegrationTest {
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), creds)
     }
 
+    @Override
     @SuppressWarnings("CatchException")
-    def cleanup() {
+    void cleanup() {
         if(Functions.isWindows()) {
             try {
                 println 'Killing Gradle processes'


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents. See https://github.com/jenkinsci/lockable-resources-plugin/pull/743#issuecomment-2598199297 for more background.

The actual migration from EE 8 to EE 9 is small, but the requirement of 2.479.x or newer (which requires Java 17 or newer) is nontrivial when it comes to updating this plugin's tests. I have made a minimal effort to update the build, but I am leaving the updating of the tests to the plugin maintainers.

### Testing done

I did some light testing locally but did not get all the automated tests to pass. (For that matter, https://ci.jenkins.io/job/Plugins/job/gradle-plugin/job/master/ is also failing at this moment.) I am leaving the updating of the tests to the plugin maintainers, who are more familiar with this plugin and Gradle Java requirements.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
