### PR TITLE
Ignore SSL errors for short lived token request if allowUntrusted

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -34,7 +34,7 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
     private final ShortLivedTokenClient tokenClient;
 
     public BuildScanEnvironmentContributor() {
-        this.tokenClient = new ShortLivedTokenClient();
+        this.tokenClient = new ShortLivedTokenClient(InjectionConfig.get().isAllowUntrusted());
     }
 
     public BuildScanEnvironmentContributor(ShortLivedTokenClient tokenClient) {


### PR DESCRIPTION
If a user allows a build scan to be published to an untrusted server (can be enabled in the Develocity Injection configuration via UI), this PR makes sure to ignore any SSL errors when we resolve a short-lived token from that server.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
