### PR TITLE
Create short-lived tokens if Develocity injection is disabled

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -43,7 +43,7 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
 
     @Override
     public void buildEnvironmentFor(@Nonnull Run run, @Nonnull EnvVars envs, @Nonnull TaskListener listener) {
-        if (InjectionConfig.get().isDisabled() || alreadyExecuted(run)) {
+        if (alreadyExecuted(run)) {
             return;
         }
 

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
@@ -1,6 +1,17 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:c="/lib/credentials">
     <f:section title="${%Develocity integration}">
+       <f:entry title="Develocity Access Key credential ID" field="accessKeyCredentialId">
+           <div class="alert alert-info" role="alert">
+               <l:icon class="icon-help icon-sm" alt="${%Access key format help}"/>
+               The access key must be in the <b><span>&lt;</span>server host name<span>&gt;</span>=<span>&lt;</span>access key<span>&gt;</span></b> format.
+               For more details please refer to the <a class="alert-link" href="https://docs.gradle.com/enterprise/gradle-plugin/#manual_access_key_configuration" target="_blank">documentation</a>.
+           </div>
+           <c:select default="${instance.accessKeyCredentialId}"/>
+       </f:entry>
+       <f:entry title="${%Develocity short-lived access tokens expiry}" field="shortLivedTokenExpiry">
+           <f:textbox checkMethod="post"/>
+       </f:entry>
         <f:optionalBlock field="enabled" title="${%Enable auto-injection}" inline="true">
 
             <j:if test="${instance.showLegacyConfigurationWarning}">
@@ -32,17 +43,6 @@
                 </f:entry>
                 <f:entry field="enforceUrl">
                     <f:checkbox title="${%Enforce Develocity server url}"/>
-                </f:entry>
-                <f:entry title="Develocity Access Key credential ID" field="accessKeyCredentialId">
-                    <div class="alert alert-info" role="alert">
-                        <l:icon class="icon-help icon-sm" alt="${%Access key format help}"/>
-                        The access key must be in the <b><span>&lt;</span>server host name<span>&gt;</span>=<span>&lt;</span>access key<span>&gt;</span></b> format.
-                        For more details please refer to the <a class="alert-link" href="https://docs.gradle.com/enterprise/gradle-plugin/#manual_access_key_configuration" target="_blank">documentation</a>.
-                    </div>
-                    <c:select default="${instance.accessKeyCredentialId}"/>
-                </f:entry>
-                <f:entry title="${%Develocity short-lived access tokens expiry}" field="shortLivedTokenExpiry">
-                    <f:textbox checkMethod="post"/>
                 </f:entry>
             </f:section>
 

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
@@ -50,19 +50,6 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         0 * run.addAction(_)
     }
 
-    def 'does nothing if Develocity injection is disabled'() {
-        given:
-        def config = InjectionConfig.get()
-        config.setEnabled(false)
-        config.save()
-
-        when:
-        buildScanEnvironmentContributor.buildEnvironmentFor(run, new EnvVars(), TaskListener.NULL)
-
-        then:
-        0 * run.addAction(_)
-    }
-
     def 'adds empty action if access key is invalid'() {
         given:
         def config = InjectionConfig.get()
@@ -112,12 +99,12 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         }
     }
 
-    def 'adds an action with the short lived token from one single access key'() {
+    def 'adds an action with the short lived token from a single access key if Develocity injection is #enabled'(boolean enabled) {
         given:
         def accessKey = "localhost=secret"
         def accessKeyCredentialId = UUID.randomUUID().toString()
         def config = InjectionConfig.get()
-        config.setEnabled(true)
+        config.setEnabled(enabled)
         config.setServer('http://localhost')
         config.setAccessKeyCredentialId(accessKeyCredentialId)
         config.save()
@@ -141,6 +128,9 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
                 paramEquals(parameters[1], 'DEVELOCITY_ACCESS_KEY', 'localhost=xyz')
             }
         }
+
+        where:
+        enabled << [true, false]
     }
 
     def 'adds an action with the short lived token with multiple keys and enforce url is true'() {


### PR DESCRIPTION
This change allows short-lived tokens creation even if Develocity Injection is disabled.

The UI has been adjusted to highlight configuration separation.

<img width="1427" alt="Screenshot 2025-04-26 at 10 58 51" src="https://github.com/user-attachments/assets/90e0c61d-3ec3-48ad-8d35-6d45441b7758" />
