### PR TITLE
Take into account allowUntrusted when changed at runtime

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
+++ b/src/main/java/hudson/plugins/gradle/injection/BuildScanEnvironmentContributor.java
@@ -13,6 +13,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.gradle.DevelocityLogger;
 import hudson.plugins.gradle.injection.token.ShortLivedTokenClient;
+import hudson.plugins.gradle.injection.token.ShortLivedTokenClientFactory;
 import hudson.util.Secret;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
@@ -31,14 +32,15 @@ import java.util.stream.Stream;
 @Extension
 public class BuildScanEnvironmentContributor extends EnvironmentContributor {
 
-    private final ShortLivedTokenClient tokenClient;
+    private final ShortLivedTokenClientFactory shortLivedTokenClientFactory;
 
     public BuildScanEnvironmentContributor() {
-        this.tokenClient = new ShortLivedTokenClient(InjectionConfig.get().isAllowUntrusted());
+        this.shortLivedTokenClientFactory = new ShortLivedTokenClientFactory();
     }
 
-    public BuildScanEnvironmentContributor(ShortLivedTokenClient tokenClient) {
-        this.tokenClient = tokenClient;
+    // required for testing
+    public BuildScanEnvironmentContributor(ShortLivedTokenClientFactory shortLivedTokenClientFactory) {
+        this.shortLivedTokenClientFactory = shortLivedTokenClientFactory;
     }
 
     @Override
@@ -83,6 +85,7 @@ public class BuildScanEnvironmentContributor extends EnvironmentContributor {
             return null;
         }
         String serverUrl = InjectionConfig.get().getServer();
+        ShortLivedTokenClient tokenClient = shortLivedTokenClientFactory.create(InjectionConfig.get().isAllowUntrusted());
 
         // If we know the URL or there's only one access key configured corresponding to the right URL
         if (InjectionConfig.get().isEnforceUrl() || allKeys.isSingleKey()) {

--- a/src/main/java/hudson/plugins/gradle/injection/token/ShortLivedTokenClientFactory.java
+++ b/src/main/java/hudson/plugins/gradle/injection/token/ShortLivedTokenClientFactory.java
@@ -1,0 +1,12 @@
+package hudson.plugins.gradle.injection.token;
+
+/**
+ * Factory is needed to create a new instance based on `allowUntrusted` which can be changed at runtime.
+ */
+public class ShortLivedTokenClientFactory {
+
+    public ShortLivedTokenClient create(boolean allowUntrusted) {
+        return new ShortLivedTokenClient(allowUntrusted);
+    }
+
+}

--- a/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
+++ b/src/test/groovy/hudson/plugins/gradle/injection/BuildScanEnvironmentContributorTest.groovy
@@ -10,6 +10,7 @@ import hudson.model.TaskListener
 import hudson.plugins.gradle.BaseJenkinsIntegrationTest
 import hudson.plugins.gradle.injection.BuildScanEnvironmentContributor.DevelocityParametersAction
 import hudson.plugins.gradle.injection.token.ShortLivedTokenClient
+import hudson.plugins.gradle.injection.token.ShortLivedTokenClientFactory
 import hudson.util.Secret
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
 import spock.lang.Subject
@@ -17,10 +18,10 @@ import spock.lang.Subject
 class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
 
     def run = Mock(Run)
-    def shortLivedTokenClient = Mock(ShortLivedTokenClient)
+    def shortLivedTokenClientFactory = Mock(ShortLivedTokenClientFactory)
 
     @Subject
-    def buildScanEnvironmentContributor = new BuildScanEnvironmentContributor(shortLivedTokenClient)
+    def buildScanEnvironmentContributor = new BuildScanEnvironmentContributor(shortLivedTokenClientFactory)
 
     def 'does nothing if no access key'() {
         given:
@@ -113,6 +114,8 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
 
         def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
 
+        ShortLivedTokenClient shortLivedTokenClient = Mock(ShortLivedTokenClient)
+        shortLivedTokenClientFactory.create(false) >> shortLivedTokenClient
         shortLivedTokenClient.get(config.getServer(), key, null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
 
         when:
@@ -147,7 +150,8 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         createStringCredentials(accessKeyCredentialId, accessKey)
 
         def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
-
+        ShortLivedTokenClient shortLivedTokenClient = Mock(ShortLivedTokenClient)
+        shortLivedTokenClientFactory.create(false) >> shortLivedTokenClient
         shortLivedTokenClient.get(config.getServer(), key, null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
 
         when:
@@ -176,7 +180,8 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         config.save()
 
         createStringCredentials(accessKeyCredentialId, accessKey)
-
+        ShortLivedTokenClient shortLivedTokenClient = Mock(ShortLivedTokenClient)
+        shortLivedTokenClientFactory.create(false) >> shortLivedTokenClient
         shortLivedTokenClient.get("https://localhost", DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'secret'), null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
         shortLivedTokenClient.get("https://other", DevelocityAccessCredentials.HostnameAccessKey.of('other', 'secret2'), null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('other', 'abc'))
 
@@ -234,7 +239,8 @@ class BuildScanEnvironmentContributorTest extends BaseJenkinsIntegrationTest {
         createUsernamePasswordCredentials(repositoryPasswordCredentialId, "john", "foo")
 
         def key = DevelocityAccessCredentials.parse(accessKey).find('localhost').get()
-
+        ShortLivedTokenClient shortLivedTokenClient = Mock(ShortLivedTokenClient)
+        shortLivedTokenClientFactory.create(false) >> shortLivedTokenClient
         shortLivedTokenClient.get(config.getServer(), key, null) >> Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz'))
 
         when:


### PR DESCRIPTION
Since `allowUntrusted` can be changed at runtime and it's unclear how Jenkins may manage the lifecycle of EnvironmentContributor, it's safer to just create a new instance of the client every time we need it (performance wise this is fine, as the token is requested once per build)