### PR TITLE
Rename input files to file fingerprints in UI

### DIFF
--- a/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
+++ b/src/main/java/hudson/plugins/gradle/injection/MavenBuildScanInjection.java
@@ -96,9 +96,9 @@ public class MavenBuildScanInjection implements MavenInjectionAware {
                 systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_ALLOW_UNTRUSTED_SERVER_PROPERTY_KEY, "true"));
             }
 
-            String captureGoalInputFiles = Optional.ofNullable(config.isMavenCaptureGoalInputFiles()).map(b -> Boolean.toString(b)).orElse("true");
-            systemProperties.add(new SystemProperty(DEVELOCITY_CAPTURE_FILE_FINGERPRINTS_PROPERTY_KEY, captureGoalInputFiles));
-            systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_CAPTURE_GOAL_INPUT_FILES_PROPERTY_KEY, captureGoalInputFiles));
+            String captureFileFingerprints = Optional.ofNullable(config.isMavenCaptureGoalInputFiles()).map(b -> Boolean.toString(b)).orElse("true");
+            systemProperties.add(new SystemProperty(DEVELOCITY_CAPTURE_FILE_FINGERPRINTS_PROPERTY_KEY, captureFileFingerprints));
+            systemProperties.add(new SystemProperty(GRADLE_ENTERPRISE_CAPTURE_GOAL_INPUT_FILES_PROPERTY_KEY, captureFileFingerprints));
 
             EnvUtil.setEnvVar(node, MavenOptsHandler.MAVEN_OPTS, MAVEN_OPTS_HANDLER.merge(node, systemProperties));
 

--- a/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/gradle/injection/InjectionConfig/config.jelly
@@ -99,7 +99,7 @@
                     </f:repeatableProperty>
                 </f:entry>
                 <f:entry field="gradleCaptureTaskInputFiles">
-                    <f:checkbox title="${%Capture Task Input Files}" default="true"/>
+                    <f:checkbox title="${%Capture File Fingerprints}" default="true"/>
                 </f:entry>
             </f:section>
 
@@ -143,7 +143,7 @@
                     </f:repeatableProperty>
                 </f:entry>
                 <f:entry field="mavenCaptureGoalInputFiles">
-                    <f:checkbox title="${%Capture Goal Input Files}" default="true"/>
+                    <f:checkbox title="${%Capture File Fingerprints}" default="true"/>
                 </f:entry>
             </f:section>
 


### PR DESCRIPTION
A simple rename of input files to file fingerprints in UI as it reflects the rename done on build agents' side a while back.