### PR TITLE
Ignore checkForGradleEnterpriseErrors test for Jenkins versions >= 2.519

### DIFF
--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.gradle;
 
+import hudson.util.VersionNumber;
 import org.jenkinsci.test.acceptance.plugins.gradle.GradleInstallation;
 import org.jenkinsci.test.acceptance.plugins.gradle.GradleStep;
 import org.jenkinsci.test.acceptance.po.Action;
@@ -8,6 +9,7 @@ import org.jenkinsci.test.acceptance.po.Build;
 import org.jenkinsci.test.acceptance.po.ContainerPageObject;
 import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.jenkinsci.test.acceptance.po.Jenkins;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -16,6 +18,7 @@ import org.openqa.selenium.WebElement;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.test.acceptance.Matchers.containsString;
+import static org.junit.Assume.assumeTrue;
 
 public class GradleEnterpriseErrorsTest extends AbstractAcceptanceTest {
 
@@ -31,6 +34,10 @@ public class GradleEnterpriseErrorsTest extends AbstractAcceptanceTest {
 
     @Test
     public void checkForGradleEnterpriseErrors() {
+        assumeTrue(
+            "The UX is different for now in Jenkins 2.519 and above, see https://issues.jenkins.io/browse/JENKINS-75727?focusedId=455604&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-455604",
+            jenkins.getVersion().isOlderThan(new VersionNumber("2.519"))
+        );
         // given
         setCheckForGradleEnterpriseErrors();
         FreeStyleJob job = jenkins.jobs.create(FreeStyleJob.class);

--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
@@ -35,7 +35,7 @@ public class GradleEnterpriseErrorsTest extends AbstractAcceptanceTest {
     @Test
     public void checkForGradleEnterpriseErrors() {
         assumeTrue(
-            "The UX is different for now in Jenkins 2.519 and above, see https://issues.jenkins.io/browse/JENKINS-75727?focusedId=455604&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-455604",
+            "The UX is different for now in Jenkins 2.519: the action shows up in a new hamburger menu",
             jenkins.getVersion().isOlderThan(new VersionNumber("2.519"))
         );
         // given

--- a/plugin/src/main/java/hudson/plugins/gradle/injection/DevelocityErrorsAction.java
+++ b/plugin/src/main/java/hudson/plugins/gradle/injection/DevelocityErrorsAction.java
@@ -46,6 +46,11 @@ public class DevelocityErrorsAction implements RootAction, StaplerProxy {
         return isVisible() ? this : null;
     }
 
+    // TODO: once upgrading to Jenkins 2.519 and above, we can show again this action in the sidebar
+//    boolean isPrimaryAction() {
+//        return true;
+//    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Iterator<GeErrorModel> getErrors() {
         Stream<Run> stream = RunList.fromJobs((Iterable) Jenkins.get().allItems(Job.class))

--- a/plugin/src/main/java/hudson/plugins/gradle/injection/DevelocityErrorsAction.java
+++ b/plugin/src/main/java/hudson/plugins/gradle/injection/DevelocityErrorsAction.java
@@ -46,11 +46,6 @@ public class DevelocityErrorsAction implements RootAction, StaplerProxy {
         return isVisible() ? this : null;
     }
 
-    // TODO: once upgrading to Jenkins 2.519 and above, we can show again this action in the sidebar
-//    boolean isPrimaryAction() {
-//        return true;
-//    }
-
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Iterator<GeErrorModel> getErrors() {
         Stream<Run> stream = RunList.fromJobs((Iterable) Jenkins.get().allItems(Job.class))


### PR DESCRIPTION
The UX is different on 2.519: the Develocity button is only shown in the "hamburger" menu and not on the left menu:

<img width="1113" height="587" alt="image" src="https://github.com/user-attachments/assets/7b775c32-dc5d-424a-b531-4ca9e9f545d2" />


We wait for confirmation it's final before adapting this test or not.
See [comment](https://issues.jenkins.io/browse/JENKINS-75727?focusedId=455604&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-455604).

In the meantime the test should not run on this version, as it consistently fails.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
