### PR TITLE
Ignore checkForGradleEnterpriseErrors test for Jenkins versions >= 2.516

### DIFF
--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
@@ -35,8 +35,8 @@ public class GradleEnterpriseErrorsTest extends AbstractAcceptanceTest {
     @Test
     public void checkForGradleEnterpriseErrors() {
         assumeTrue(
-            "The UX is different for now in Jenkins 2.519: the action shows up in a new hamburger menu",
-            jenkins.getVersion().isOlderThan(new VersionNumber("2.519"))
+            "The UX is different for now in Jenkins 2.516: the action shows up in a new hamburger menu",
+            jenkins.getVersion().isOlderThan(new VersionNumber("2.516"))
         );
         // given
         setCheckForGradleEnterpriseErrors();


### PR DESCRIPTION
Follow-up of https://github.com/jenkinsci/gradle-plugin/pull/619

Turns out the new UI is effective since 2.516, which is the next LTS.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
