### PR TITLE
Adapt to future Build Scan publication message

### DIFF
--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/AbstractAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/AbstractAcceptanceTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractAcceptanceTest extends AbstractJUnitTest {
 
     protected static final URI PUBLIC_DEVELOCITY_SERVER = URI.create("https://scans.gradle.com");
 
-    private static final String DEVELOCITY_MAVEN_EXTENSION_VERSION = "2.0";
+    private static final String DEVELOCITY_MAVEN_EXTENSION_VERSION = "2.1";
 
     @Rule
     public MockGeServer mockGeServer = new MockGeServer();

--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleEnterpriseErrorsTest.java
@@ -103,6 +103,7 @@ public class GradleEnterpriseErrorsTest extends AbstractAcceptanceTest {
         assertThat(output, containsString("Internal error in Gradle Enterprise Gradle plugin"));
         assertThat(output, not(containsString("Publishing build scan...")));
         assertThat(output, not(containsString("Publishing Build Scan...")));
+        assertThat(output, not(containsString("Publishing Build Scan to Develocity...")));
     }
 
 }

--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleInjectionTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/GradleInjectionTest.java
@@ -206,7 +206,7 @@ public class GradleInjectionTest extends AbstractAcceptanceTest {
         assertThat(output, containsString("> Task :helloWorld"));
         assertThat(output, containsString("Hello, World!"));
 
-        assertThat(output, containsRegexp("Publishing (build scan|Build Scan)\\.\\.\\."));
+        assertThat(output, containsRegexp("Publishing (build scan|Build Scan)(?: to Develocity)?\\.\\.\\."));
         assertThat(output, not(containsString(mockGeServer.publicBuildScanId())));
         assertThat(output, containsString("Publishing failed."));
 
@@ -335,6 +335,7 @@ public class GradleInjectionTest extends AbstractAcceptanceTest {
         assertThat(output, not(containsString("Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin via init script")));
         assertRequiredLogLines(output, requiredLogsLines);
         assertThat(output, not(containsString("Publishing Build Scan...")));
+        assertThat(output, not(containsString("Publishing Build Scan to Develocity...")));
         assertThat(output, not(containsString("Publishing build scan...")));
     }
 
@@ -357,7 +358,7 @@ public class GradleInjectionTest extends AbstractAcceptanceTest {
             containsRegexp("Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin with version (.*) via init script");
         assertThat(output, requireAppliedViaInitScript ? appliedViaInitScriptMatcher : not(appliedViaInitScriptMatcher));
         assertRequiredLogLines(output, requiredLogsLines);
-        assertThat(output, containsRegexp("Publishing (Build Scan|build scan)\\.\\.\\." + System.lineSeparator() + mockGeServer.publicBuildScanId()));
+        assertThat(output, containsRegexp("Publishing (Build Scan|build scan)(?: to Develocity)?\\.\\.\\." + System.lineSeparator() + mockGeServer.publicBuildScanId()));
     }
 
     private void assertRequiredLogLines(String output, String... requiredLogsLines) {

--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/MavenEnrichedScansTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/MavenEnrichedScansTest.java
@@ -51,7 +51,8 @@ public class MavenEnrichedScansTest extends AbstractAcceptanceTest {
         String output = build.getConsole();
         assertThat(output, Matchers.anyOf(
             containsString("[INFO] Publishing build scan..." + System.lineSeparator() + "[INFO] https://gradle.com/s/"),
-            containsString("[INFO] Publishing Build Scan..." + System.lineSeparator() + "[INFO] https://gradle.com/s/")
+            containsString("[INFO] Publishing Build Scan..." + System.lineSeparator() + "[INFO] https://gradle.com/s/"),
+            containsString("[INFO] Publishing Build Scan to Develocity..." + System.lineSeparator() + "[INFO] https://gradle.com/s/")
         ));
 
         // Build scans on public instance are not enriched

--- a/acceptance-tests/src/test/java/hudson/plugins/gradle/MavenInjectionTest.java
+++ b/acceptance-tests/src/test/java/hudson/plugins/gradle/MavenInjectionTest.java
@@ -165,7 +165,8 @@ public class MavenInjectionTest extends AbstractAcceptanceTest {
         assertThat(output, either(containsString("[INFO] 3 goals, 2 executed, 1 from cache")).or(containsString("[INFO] 3 goals, 3 executed")));
         assertThat(output, either(
             containsString("[INFO] Publishing build scan..." + System.lineSeparator() + "[INFO] https://gradle.com/s/")).or(
-            containsString("[INFO] Publishing Build Scan..." + System.lineSeparator() + "[INFO] https://gradle.com/s/"))
+            containsString("[INFO] Publishing Build Scan..." + System.lineSeparator() + "[INFO] https://gradle.com/s/")).or(
+            containsString("[INFO] Publishing Build Scan to Develocity..." + System.lineSeparator() + "[INFO] https://gradle.com/s/"))
         );
     }
 
@@ -173,5 +174,6 @@ public class MavenInjectionTest extends AbstractAcceptanceTest {
         String output = build.getConsole();
         assertThat(output, not(containsString("[INFO] Publishing build scan...")));
         assertThat(output, not(containsString("[INFO] Publishing Build Scan...")));
+        assertThat(output, not(containsString("[INFO] Publishing Build Scan to Develocity...")));
     }
 }

--- a/acceptance-tests/src/test/resources/mvn_extensions_with_ge.xml
+++ b/acceptance-tests/src/test/resources/mvn_extensions_with_ge.xml
@@ -2,6 +2,6 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>2.0</version>
+        <version>2.1</version>
     </extension>
 </extensions>

--- a/plugin/src/main/java/hudson/plugins/gradle/BuildScanLogScanner.java
+++ b/plugin/src/main/java/hudson/plugins/gradle/BuildScanLogScanner.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 
 public class BuildScanLogScanner {
 
-    private static final Pattern BUILD_SCAN_PATTERN = Pattern.compile("Publishing (Build Scan|build scan|build information)\\.\\.\\.");
+    private static final Pattern BUILD_SCAN_PATTERN = Pattern.compile("Publishing (Build Scan|build scan|build information)(?: to Develocity)?\\.\\.\\.");
     private static final Pattern URL_PATTERN = Pattern.compile(".*(?:\\[INFO] )?(https?://.*/s/.*)");
     private static final int LINES_TO_SCAN = 1000;
 

--- a/plugin/src/test/groovy/hudson/plugins/gradle/BuildScanLogScannerTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/BuildScanLogScannerTest.groovy
@@ -24,6 +24,7 @@ class BuildScanLogScannerTest extends Specification {
         'One build scan URL'                   | logWithBuildScans(["https://scans.gradle.com/s/bzb4vn64kx3bc"])                                             || ["https://scans.gradle.com/s/bzb4vn64kx3bc"]
         'One build scan URL with old term'     | logWithBuildScans(["https://scans.gradle.com/s/bzb4vn64kx3bc"], 10, 'build information')                    || ["https://scans.gradle.com/s/bzb4vn64kx3bc"]
         'One build scan URL with new term'     | logWithBuildScans(["https://scans.gradle.com/s/bzb4vn64kx3bc"], 10, 'Build Scan')                           || ["https://scans.gradle.com/s/bzb4vn64kx3bc"]
+        'One build scan URL with newest term'  | logWithBuildScans(["https://scans.gradle.com/s/bzb4vn64kx3bc"], 10, 'Build Scan to Develocity')             || ["https://scans.gradle.com/s/bzb4vn64kx3bc"]
         'Two build scan URLs'                  | logWithBuildScans(["https://scans.gradle.com/s/bzb4vn64kx3bc", "https://scans.gradle.com/s/asc9wm73ly1do"]) || ["https://scans.gradle.com/s/bzb4vn64kx3bc", "https://scans.gradle.com/s/asc9wm73ly1do"]
         'Non build scan URL'                   | logWithBuildScans(["https://scans.gradle.com/bzb4vn64kx3bc"])                                               || []
         'Too many lines before build scan URL' | logWithBuildScans(["https://scans.gradle.com/s/bzb4vn64kx3bc"], 1010)                                       || []

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenCrossVersionTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenCrossVersionTest.groovy
@@ -20,7 +20,7 @@ class BuildScanInjectionMavenCrossVersionTest extends BaseMavenIntegrationTest {
         withInjectionConfig {
             enabled = true
             server = 'https://scans.gradle.com'
-            mavenExtensionVersion = '2.0'
+            mavenExtensionVersion = '2.1'
             ccudExtensionVersion = '2.0'
         }
 

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionMavenIntegrationTest.groovy
@@ -309,12 +309,12 @@ class BuildScanInjectionMavenIntegrationTest extends BaseMavenIntegrationTest {
             accessKeyCredentialId = credentialId
         }
         SystemCredentialsProvider.getInstance().getCredentials().add(
-                new StringCredentialsImpl(
-                        CredentialsScope.GLOBAL,
-                        credentialId,
-                        "Develocity Access Key",
-                        Secret.fromString("localhost=secret")
-                ))
+            new StringCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                credentialId,
+                "Develocity Access Key",
+                Secret.fromString("localhost=secret")
+            ))
         SystemCredentialsProvider.getInstance().save()
 
         def pipelineJob = j.createProject(WorkflowJob)
@@ -360,12 +360,12 @@ node {
             accessKeyCredentialId = credentialId
         }
         SystemCredentialsProvider.getInstance().getCredentials().add(
-                new StringCredentialsImpl(
-                        CredentialsScope.GLOBAL,
-                        credentialId,
-                        "Develocity Access Key",
-                        Secret.fromString("secret")
-                ))
+            new StringCredentialsImpl(
+                CredentialsScope.GLOBAL,
+                credentialId,
+                "Develocity Access Key",
+                Secret.fromString("secret")
+            ))
         SystemCredentialsProvider.getInstance().save()
         def pipelineJob = j.createProject(WorkflowJob)
         pipelineJob.setDefinition(new CpsFlowDefinition(simplePipeline(mavenInstallationName), false))
@@ -479,7 +479,7 @@ node {
         withInjectionConfig {
             enabled = true
             server = "https://scans.gradle.com"
-            mavenExtensionVersion = '2.0'
+            mavenExtensionVersion = '2.1'
             checkForBuildAgentErrors = false
         }
         def secondRun = buildAndAssertFailure(p)
@@ -511,7 +511,7 @@ node {
         withInjectionConfig {
             enabled = true
             server = "https://scans.gradle.com"
-            mavenExtensionVersion = '2.0'
+            mavenExtensionVersion = '2.1'
             checkForBuildAgentErrors = true
         }
         def secondRun = buildAndAssertFailure(p)
@@ -607,7 +607,7 @@ node {
         withInjectionConfig {
             enabled = true
             server = "https://scans.gradle.com"
-            mavenExtensionVersion = '2.0'
+            mavenExtensionVersion = '2.1'
             ccudExtensionVersion = '2.0'
         }
 
@@ -815,6 +815,7 @@ node {
         if (isUrlEnforced) {
             assertThat(j.getLog(build), anyOf(
                 containsString('Publishing Build Scan...'),
+                containsString('Publishing Build Scan to Develocity...'),
                 containsString('Publishing build scan...')
             ))
         } else {
@@ -911,6 +912,7 @@ node {
         if (isUrlEnforced) {
             assertThat(j.getLog(build), anyOf(
                 containsString('Publishing Build Scan...'),
+                containsString('Publishing Build Scan to Develocity...'),
                 containsString('Publishing build scan...')
             ))
         } else {
@@ -1017,7 +1019,7 @@ node {
         withInjectionConfig {
             enabled = true
             server = 'https://scans.gradle.com'
-            mavenExtensionVersion = '2.0'
+            mavenExtensionVersion = '2.1'
         }
 
         createSlave('foo')
@@ -1046,7 +1048,7 @@ node {
     }
 
     private static boolean hasBuildScanPublicationAttempt(String log) {
-        (log =~ /The build scan was not published due to a configuration problem/).find()
+        (log =~ /The Build Scan was not published due to a configuration problem/).find()
     }
 
     private void assertNoDoubleApplication(Run build) {
@@ -1069,7 +1071,7 @@ node {
         withInjectionConfig {
             enabled = true
             server = 'https://scans.gradle.com'
-            mavenExtensionVersion = '2.0'
+            mavenExtensionVersion = '2.1'
             ccudExtensionVersion = useCCUD ? '2.0' : ''
             mavenCaptureGoalInputFiles = captureGoalInputFiles
         }

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigTest.groovy
@@ -176,7 +176,7 @@ class InjectionConfigTest extends BaseJenkinsIntegrationTest {
         getAddButton(form, "Gradle auto-injection disabled nodes").click()
         form.getInputsByName("_.label").last().setValueAttribute("gradle2")
 
-        form.getInputByName("_.mavenExtensionVersion").setValueAttribute("2.0")
+        form.getInputByName("_.mavenExtensionVersion").setValueAttribute("2.1")
         form.getInputByName("_.ccudExtensionVersion").setValueAttribute("2.0")
 
         getAddButton(form, "Maven auto-injection enabled nodes").click()
@@ -201,7 +201,7 @@ class InjectionConfigTest extends BaseJenkinsIntegrationTest {
             gradleInjectionEnabledNodes*.label == ['gradle1']
             gradleInjectionDisabledNodes*.label == ['gradle2']
 
-            mavenExtensionVersion == "2.0"
+            mavenExtensionVersion == "2.1"
             ccudExtensionVersion == "2.0"
             mavenInjectionEnabledNodes*.label == ['maven1']
             mavenInjectionDisabledNodes*.label == ['maven2']
@@ -248,7 +248,7 @@ class InjectionConfigTest extends BaseJenkinsIntegrationTest {
       <label>gradle2</label>
     </hudson.plugins.gradle.injection.NodeLabelItem>
   </gradleInjectionDisabledNodes>
-  <mavenExtensionVersion>2.0</mavenExtensionVersion>
+  <mavenExtensionVersion>2.1</mavenExtensionVersion>
   <ccudExtensionVersion>2.0</ccudExtensionVersion>
   <mavenExtensionRepositoryUrl>https://localhost/repostiry</mavenExtensionRepositoryUrl>
   <mavenInjectionEnabledNodes>
@@ -295,7 +295,7 @@ class InjectionConfigTest extends BaseJenkinsIntegrationTest {
       <label>gradle2</label>
     </hudson.plugins.gradle.injection.NodeLabelItem>
   </gradleInjectionDisabledNodes>
-  <mavenExtensionVersion>2.0</mavenExtensionVersion>
+  <mavenExtensionVersion>2.1</mavenExtensionVersion>
   <ccudExtensionVersion>2.0</ccudExtensionVersion>
   <mavenExtensionRepositoryUrl>https://localhost/repostiry</mavenExtensionRepositoryUrl>
   <mavenInjectionEnabledNodes>

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigWithCasCTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/InjectionConfigWithCasCTest.groovy
@@ -36,7 +36,7 @@ class InjectionConfigWithCasCTest extends AbstractIntegrationTest {
             it.mavenCaptureGoalInputFiles == true
             it.mavenExtensionCustomCoordinates == "mycustom:ext"
             it.mavenExtensionRepositoryUrl == "https://repo1.maven.org/maven2"
-            it.mavenExtensionVersion == "2.0"
+            it.mavenExtensionVersion == "2.1"
             it.mavenInjectionDisabledNodes*.label == ["non-maven-node"]
             it.mavenInjectionEnabledNodes*.label == ["maven-node"]
             it.server == "http://localhost:5086"

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionDownloadHandlerTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionDownloadHandlerTest.groovy
@@ -21,7 +21,7 @@ class MavenExtensionDownloadHandlerTest extends Specification {
         with(originalConfig) {
             enabled >> true
             server >> 'https://scans.gradle.com'
-            mavenExtensionVersion >> '2.0'
+            mavenExtensionVersion >> '2.1'
             ccudExtensionVersion >> '2.0.1'
         }
 
@@ -81,7 +81,7 @@ class MavenExtensionDownloadHandlerTest extends Specification {
         with(updatedConfig) {
             enabled >> true
             server >> 'https://scans.gradle.com'
-            mavenExtensionVersion >> '2.0'
+            mavenExtensionVersion >> '2.1'
             ccudExtensionVersion >> '2.0.1'
         }
 

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsDetectorTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsDetectorTest.groovy
@@ -21,7 +21,7 @@ class MavenExtensionsDetectorTest extends Specification {
     def 'detect DV and CCUD extension'() {
         given:
         with(injectionConfig) {
-            mavenExtensionVersion >> '2.0'
+            mavenExtensionVersion >> '2.1'
             mavenExtensionCustomCoordinates >> customCoordinates
             ccudExtensionCustomCoordinates >> ccudCustomCoordinates
         }
@@ -84,7 +84,7 @@ class MavenExtensionsDetectorTest extends Specification {
     def 'do not detect DV and CCUD extension when extensions file is not present'() {
         given:
         with(injectionConfig) {
-            mavenExtensionVersion >> '2.0'
+            mavenExtensionVersion >> '2.1'
         }
         def workspace = tempFolder.newFolder('workspace')
 

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenExtensionsHandlerTest.groovy
@@ -50,7 +50,7 @@ class MavenExtensionsHandlerTest extends Specification {
 
         cacheDirectory.child(MavenExtension.DEVELOCITY.getEmbeddedJarName()).write()
                 .withCloseable {
-                    extensionClient.downloadExtension(MavenExtension.DEVELOCITY.createDownloadUrl("2.0", null), null, it)
+                    extensionClient.downloadExtension(MavenExtension.DEVELOCITY.createDownloadUrl("2.1", null), null, it)
                 }
 
         cacheDirectory.child(MavenExtension.CCUD.getEmbeddedJarName()).write()
@@ -81,7 +81,7 @@ class MavenExtensionsHandlerTest extends Specification {
 
         cacheDirectory.child(MavenExtension.DEVELOCITY.getEmbeddedJarName()).write()
                 .withCloseable {
-                    extensionClient.downloadExtension(MavenExtension.DEVELOCITY.createDownloadUrl("2.0", null), null, it)
+                    extensionClient.downloadExtension(MavenExtension.DEVELOCITY.createDownloadUrl("2.1", null), null, it)
                 }
 
         cacheDirectory.child(MavenExtension.CCUD.getEmbeddedJarName()).write()

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenSnippets.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/MavenSnippets.groovy
@@ -34,7 +34,7 @@ class MavenSnippets {
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>2.0</version>
+        <version>2.1</version>
     </extension>
 </extensions>
 '''

--- a/plugin/src/test/resources/injection-config.yml
+++ b/plugin/src/test/resources/injection-config.yml
@@ -20,7 +20,7 @@ unclassified:
         mavenCaptureGoalInputFiles: true
         mavenExtensionCustomCoordinates: "mycustom:ext"
         mavenExtensionRepositoryUrl: "https://repo1.maven.org/maven2"
-        mavenExtensionVersion: "2.0"
+        mavenExtensionVersion: "2.1"
         mavenInjectionDisabledNodes:
             -   label: "non-maven-node"
         mavenInjectionEnabledNodes:


### PR DESCRIPTION
Similar to https://github.com/jenkinsci/gradle-plugin/pull/551, a new Build Scan publication message will be introduced in the next Develocity Gradle plugin and Develocity Maven extension. This PR adapts the console log parsing and tests. 
The Maven extension used in tests is also bumped, but it's not related to this change per se.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
