### PR TITLE
Remove UNVERSIONED

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.gradle</groupId>
     <artifactId>gradle-plugin-acceptance-tests</artifactId>
-    <version>UNVERSIONED</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>Gradle Plugin Acceptance Tests</name>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <revision>2.16</revision>
+        <revision>2.17</revision>
         <changelist>999999-SNAPSHOT</changelist>
 
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,15 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>gradle-pom</artifactId>
-    <version>UNVERSIONED</version>
+    <version>${revision}.${changelist}</version>
     <packaging>pom</packaging>
 
     <name>Gradle Plugin parent pom</name>
+
+    <properties>
+        <revision>2.17</revision>
+        <changelist>999999-SNAPSHOT</changelist>
+    </properties>
 
     <modules>
         <module>plugin</module>


### PR DESCRIPTION
The parent pom contained `UNVERSIONED` as a version name, since it's not meant to be published anywhere.
Unfortunately, this version is used by the infra scripts to create the GH tag and release. Since Maven 3.x does not allow to use variables to reference the parent pom, we need to duplicate those.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
