### PR TITLE
Fix flaky tests on Windows

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -298,7 +298,7 @@
                         <exclude>**/*IntegrationTest.java</exclude>
                     </excludes>
                     <reuseForks>false</reuseForks>
-                    <forkCount>2</forkCount>
+                    <forkCount>1C</forkCount>
                 </configuration>
             </plugin>
             <plugin>
@@ -307,7 +307,7 @@
                 <version>3.5.3</version>
                 <executions>
                     <execution>
-                        <id>integration-tests</id>
+                        <id>integration-tests-seq</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -316,8 +316,28 @@
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
                             </includes>
+                            <groups>
+                                sequential
+                            </groups>
                             <reuseForks>false</reuseForks>
-                            <forkCount>2</forkCount>
+                            <forkCount>1</forkCount>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-tests-parallel</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                            <groups>
+                                parallel
+                            </groups>
+                            <reuseForks>false</reuseForks>
+                            <forkCount>1C</forkCount>
                         </configuration>
                     </execution>
                 </executions>

--- a/plugin/src/test/groovy/hudson/plugins/gradle/BaseJenkinsIntegrationTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/BaseJenkinsIntegrationTest.groovy
@@ -2,10 +2,12 @@ package hudson.plugins.gradle
 
 import org.junit.Rule
 import org.junit.rules.RuleChain
+import spock.lang.Tag
 
 /**
  * Base class for tests that need a Jenkins instance.
  */
+@Tag('parallel')
 abstract class BaseJenkinsIntegrationTest extends AbstractIntegrationTest {
 
     @Rule

--- a/plugin/src/test/groovy/hudson/plugins/gradle/BaseMavenIntegrationTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/BaseMavenIntegrationTest.groovy
@@ -2,10 +2,12 @@ package hudson.plugins.gradle
 
 import org.junit.Rule
 import org.junit.rules.RuleChain
+import spock.lang.Tag
 
 /**
  * Base class for tests that need a Jenkins instance and Maven tool.
  */
+@Tag('parallel')
 abstract class BaseMavenIntegrationTest extends AbstractIntegrationTest {
 
     public final MavenInstallationRule mavenInstallationRule = new MavenInstallationRule(j)

--- a/plugin/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/GradleInstallationRule.groovy
@@ -1,5 +1,6 @@
 package hudson.plugins.gradle
 
+
 import hudson.model.DownloadService
 import hudson.tools.InstallSourceProperty
 import hudson.util.FormValidation
@@ -16,7 +17,7 @@ class GradleInstallationRule extends TestWatcher {
     String gradleVersion
     private final JenkinsRule j
 
-    GradleInstallationRule(String gradleVersion = '7.3', JenkinsRule j) {
+    GradleInstallationRule(String gradleVersion = '8.14.3', JenkinsRule j) {
         this.gradleVersion = gradleVersion
         this.j = j
     }

--- a/plugin/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/GradlePluginIntegrationTest.groovy
@@ -203,7 +203,7 @@ class GradlePluginIntegrationTest extends BaseGradleIntegrationTest {
     }
 
     private Gradle configuredGradle() {
-        new Gradle(switches: 'switches', tasks: 'tasks', rootBuildScriptDir: 'buildScriptDir',
+        new Gradle(switches: '--no-daemon', tasks: 'tasks', rootBuildScriptDir: 'buildScriptDir',
             buildFile: 'buildFile.gradle', gradleName: gradleInstallationRule.gradleVersion,
             useWrapper: true, makeExecutable: true, wrapperLocation: 'path/to/wrapper',
             useWorkspaceAsHome: true, passAllAsProjectProperties: true, passAllAsSystemProperties: true,

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleIntegrationTest.groovy
@@ -38,10 +38,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
     def "does not capture build agent errors if checking for errors is disabled"() {
         given:
         System.setProperty(TimestampNote.systemProperty, 'true')
-        def gradleVersion = '8.6'
-
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -50,7 +48,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         p.buildersList.add(settingsFile())
         p.buildersList.add(helloTask())
-        p.buildersList.add(new Gradle(tasks: '-Dcom.gradle.scan.trigger-synthetic-error=true -Ddevelocity.scan.trigger-synthetic-error=true hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        p.buildersList.add(new Gradle(tasks: '-Dcom.gradle.scan.trigger-synthetic-error=true -Ddevelocity.scan.trigger-synthetic-error=true hello', *: defaults))
         p.getBuildWrappersList().add(new TimestamperBuildWrapper())
 
         when:
@@ -76,10 +74,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
     def "captures build agent errors if checking for errors is enabled"() {
         given:
         System.setProperty(TimestampNote.systemProperty, 'true')
-        def gradleVersion = '8.6'
-
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -88,7 +84,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         p.buildersList.add(settingsFile())
         p.buildersList.add(helloTask())
-        p.buildersList.add(new Gradle(tasks: '-Dcom.gradle.scan.trigger-synthetic-error=true -Ddevelocity.scan.trigger-synthetic-error=true hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        p.buildersList.add(new Gradle(tasks: '-Dcom.gradle.scan.trigger-synthetic-error=true -Ddevelocity.scan.trigger-synthetic-error=true hello', *: defaults))
         p.getBuildWrappersList().add(new TimestamperBuildWrapper())
 
         when:
@@ -118,9 +114,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "captures build agent errors in pipeline build if checking for errors is enabled"() {
         given:
-        def gradleVersion = '8.6'
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -153,9 +148,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         def secret = 'confidential'
         registerCredentials('my-creds', secret)
 
-        def gradleVersion = '8.6'
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
         def pipelineJob = GradleSnippets.pipelineJobWithCredentials(j)
@@ -182,12 +176,10 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def 'skips injection if the agent is offline'() {
         given:
-        def gradleVersion = '8.6'
-
         def agent = createSlave("test")
 
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         withGlobalEnvVars {
             put("JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_GRADLE_HOME", getGradleHome(agent, gradleVersion))
@@ -260,7 +252,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         project.buildersList.add(settingsFile())
         project.buildersList.add(helloTask())
-        project.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        project.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         when:
         // first build to download Gradle
@@ -294,7 +286,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         p.buildersList.add(settingsFile())
         p.buildersList.add(helloTask())
-        p.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        p.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         when:
         // first build to download Gradle
@@ -331,7 +323,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         p.buildersList.add(settingsFile())
         p.buildersList.add(helloTask())
-        p.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        p.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         when:
         // first build to download Gradle
@@ -371,7 +363,6 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
             sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
           } else {
             bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
-            bat(/"\${gradleHome}\\bin\\gradle.bat" --stop/)
           }
         }
       }
@@ -472,7 +463,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         p.buildersList.add(settingsFile())
         p.buildersList.add(helloTask())
-        p.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        p.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         expect:
         !initScript.exists()
@@ -527,10 +518,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "doesn't copy init script if already exists"() {
         given:
-        def gradleVersion = '8.6'
-
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -555,10 +544,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "copies init script if it was changed"() {
         given:
-        def gradleVersion = '8.6'
-
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -592,10 +579,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
     @SuppressWarnings("GStringExpressionWithinString")
     def "short lived token is injected into the build"() {
         given:
-        def gradleVersion = '8.6'
-
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -604,7 +589,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         project.buildersList.add(settingsFile())
         project.buildersList.add(helloTask('println "accessKey=${System.getenv(\'DEVELOCITY_ACCESS_KEY\')}"'))
-        project.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        project.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         def mockDevelocity = GroovyEmbeddedApp.of {
             handlers {
@@ -650,10 +635,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "invalid access key is not injected into the build"() {
         given:
-        def gradleVersion = '8.6'
-
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -662,7 +645,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         project.buildersList.add(settingsFile())
         project.buildersList.add(helloTask())
-        project.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion, switches: "--no-daemon"))
+        project.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         when:
         // first build to download Gradle
@@ -697,12 +680,10 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "sets all mandatory environment variables"() {
         given:
-        def gradleVersion = '8.6'
-
         def agent = createSlave("test")
 
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         withGlobalEnvVars {
             put("JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_GRADLE_HOME", getGradleHome(agent, gradleVersion))
@@ -759,12 +740,10 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "sets all optional environment variables"() {
         given:
-        def gradleVersion = '8.6'
-
         def agent = createSlave("test")
 
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         withGlobalEnvVars {
             put("JENKINSGRADLEPLUGIN_BUILD_SCAN_OVERRIDE_GRADLE_HOME", getGradleHome(agent, gradleVersion))
@@ -830,9 +809,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def 'vcs repository pattern injection for freestyle remote project - #filter #shouldApplyAutoInjection'(String filter, boolean shouldApplyAutoInjection) {
         given:
-        def gradleVersion = '8.6'
-        gradleInstallationRule.gradleVersion = '8.6'
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave slave = createSlave()
 
@@ -840,7 +818,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
         p.setScm(new GitSCM(GitSCM.createRepoList("https://github.com/c00ler/simple-gradle-project", null), [new BranchSpec('main')], null, null, null))
         p.setAssignedNode(slave)
 
-        p.buildersList.add(new Gradle(tasks: 'clean', gradleName: gradleVersion, switches: "--no-daemon"))
+        p.buildersList.add(new Gradle(tasks: 'clean', *: defaults))
 
         when:
         // first build to download Gradle
@@ -871,9 +849,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def 'vcs repository pattern injection for pipeline remote project - #filter #shouldApplyAutoInjection'(String filter, boolean shouldApplyAutoInjection) {
         given:
-        def gradleVersion = '8.6'
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave slave = createSlave()
 
@@ -884,12 +861,11 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
       node('foo') {
         withGradle {
           git branch: 'main', url: 'https://github.com/c00ler/simple-gradle-project'
-          def gradleHome = tool name: '${gradleInstallationRule.gradleVersion}', type: 'gradle'
+          def gradleHome = tool name: '${gradleVersion}', type: 'gradle'
           if (isUnix()) {
             sh "'\${gradleHome}/bin/gradle' help --no-daemon --console=plain"
           } else {
             bat(/"\${gradleHome}\\bin\\gradle.bat" help --no-daemon --console=plain/)
-            bat(/"\${gradleHome}\\bin\\gradle.bat" --stop/)
           }
         }
       }
@@ -925,9 +901,8 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
     def "logs injection messages with default Gradle log level"(boolean quiet) {
         given:
-        def gradleVersion = '8.1.1'
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
+        def gradleVersion = gradleInstallationRule.gradleVersion
 
         DumbSlave agent = createSlave()
 
@@ -975,7 +950,7 @@ class BuildScanInjectionGradleIntegrationTest extends BaseGradleIntegrationTest 
 
         project.buildersList.add(settingsFile())
         project.buildersList.add(helloTask())
-        project.buildersList.add(new Gradle(tasks: 'hello', gradleName: gradleVersion))
+        project.buildersList.add(new Gradle(tasks: 'hello', *: defaults))
 
         when:
         // first build to download Gradle

--- a/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
+++ b/plugin/src/test/groovy/hudson/plugins/gradle/injection/BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest.groovy
@@ -20,8 +20,6 @@ class BuildScanInjectionGradleWithDurableTaskStepUseWatchingIntegrationTest exte
     @PendingFeature
     def "cannot capture build agent errors in pipeline build if DurableTaskStep.USE_WATCHING=true"() {
         given:
-        def gradleVersion = '8.6'
-        gradleInstallationRule.gradleVersion = gradleVersion
         gradleInstallationRule.addInstallation()
 
         DumbSlave agent = createSlave('foo')


### PR DESCRIPTION
Fix Windows flaky integration tests:
- Do not execute Gradle integ test in parallel
- Use --no-daemon
- Kill any Gradle daemon after each Gradle integ test

The last step is kind of a catch-all thing, as the latest build logs show that only `captures build agent errors in pipeline build if checking for errors is enabled` seems to have a Gradle daemon leftover.


### Testing done
Ran the integration tests several times on Windows.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
