### PR TITLE
Lower required Jenkins version

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Gradle Plugin Acceptance Tests</name>
     <properties>
-        <jenkins.version>2.528.3</jenkins.version>
+        <jenkins.version>2.528.1</jenkins.version>
         <skipTests>true</skipTests>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -118,7 +118,7 @@
         <profile>
             <id>jenkinsMin</id>
             <properties>
-                <jenkins.version>2.528.3</jenkins.version>
+                <jenkins.version>2.528.1</jenkins.version>
                 <skipTests>false</skipTests>
             </properties>
         </profile>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Gradle Plugin Acceptance Tests</name>
     <properties>
-        <jenkins.version>2.528.1</jenkins.version>
+        <jenkins.version>2.528.3</jenkins.version>
         <skipTests>true</skipTests>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -118,7 +118,7 @@
         <profile>
             <id>jenkinsMin</id>
             <properties>
-                <jenkins.version>2.528.1</jenkins.version>
+                <jenkins.version>2.528.3</jenkins.version>
                 <skipTests>false</skipTests>
             </properties>
         </profile>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.version>2.528.3</jenkins.version>
+        <jenkins.version>2.528.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
         <spotless.check.skip>true</spotless.check.skip>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This change lowers the Jenkins requirement introduced in the last release from 2.528.3 to 2.528.1

We keep testing against 2.528.3 due to ATH limitations

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
